### PR TITLE
feat(parser): parse negative numbers and exponents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,6 +2500,7 @@ dependencies = [
  "arcstr",
  "enumify",
  "itertools",
+ "lazy_static",
  "nom",
  "regex",
  "rust_decimal",

--- a/libs/spice/Cargo.toml
+++ b/libs/spice/Cargo.toml
@@ -17,3 +17,4 @@ scir = { version = "0.7.0", registry = "substrate", path = "../scir" }
 substrate = { version = "0.8.1", registry = "substrate", path = "../../substrate" }
 enumify = { version = "0.1.0", path = "../enumify", registry = "substrate" }
 regex = "1.10.2"
+lazy_static = "1.4.0"

--- a/libs/spice/src/parser/conv.rs
+++ b/libs/spice/src/parser/conv.rs
@@ -302,5 +302,7 @@ mod tests {
         assert!(str_as_numeric_lit("8.88268e-19").is_ok());
         assert!(str_as_numeric_lit("-0.0175668f").is_ok());
         assert!(str_as_numeric_lit("-8.88268e-19").is_ok());
+        assert!(str_as_numeric_lit("8.88268e19").is_ok());
+        assert!(str_as_numeric_lit("-8.88268e19").is_ok());
     }
 }

--- a/libs/spice/src/parser/conv.rs
+++ b/libs/spice/src/parser/conv.rs
@@ -276,7 +276,7 @@ fn str_as_numeric_lit_inner(s: &str) -> Option<Decimal> {
             .ok()
         })
         .or_else(|| caps.get(5).and_then(|s| s.as_str().parse().ok()))
-        .unwrap_or_else(|| Decimal::one());
+        .unwrap_or_else(Decimal::one);
 
     Some(num * multiplier)
 }
@@ -285,7 +285,7 @@ fn str_as_numeric_lit(s: &str) -> std::result::Result<Decimal, ()> {
     str_as_numeric_lit_inner(s).ok_or(())
 }
 fn substr_as_numeric_lit(s: &Substr) -> ConvResult<Decimal> {
-    str_as_numeric_lit(&*s).map_err(|_| ConvError::InvalidLiteral(s.clone()))
+    str_as_numeric_lit(s).map_err(|_| ConvError::InvalidLiteral(s.clone()))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Supports parsing numeric literals containing negative numbers and/or
exponents. For example, the SPICE parser now handles "-2", "-2.3",
"-2.34e-19", or "2.34e19".
