### PR TITLE
feat(atoll): require edge-centered tracks

### DIFF
--- a/libs/atoll/src/grid.rs
+++ b/libs/atoll/src/grid.rs
@@ -56,8 +56,6 @@ pub struct AbstractLayer {
     pub line: i64,
     /// The space between adjacent tracks.
     pub space: i64,
-    /// How much to shift the first track of the layer.
-    pub offset: i64,
     /// How far to extend a track beyond the center-to-center intersection point with a track on the layer below.
     pub endcap: i64,
 }
@@ -80,7 +78,7 @@ impl AsRef<LayerId> for PdkLayer {
 impl AbstractLayer {
     /// The (infinite) set of tracks on this layer.
     pub fn tracks(&self, global_ofs: i64) -> UniformTracks {
-        UniformTracks::with_offset(self.line, self.space, self.offset + global_ofs)
+        UniformTracks::with_offset(self.line, self.space, global_ofs)
     }
 }
 
@@ -120,8 +118,9 @@ impl AtollLayer for AbstractLayer {
         self.space
     }
 
+    /// The offset, which is (currently) fixed at 0.
     fn offset(&self) -> i64 {
-        self.offset
+        0
     }
 
     fn endcap(&self) -> i64 {
@@ -1000,28 +999,24 @@ mod tests {
                     dir: RoutingDir::Horiz,
                     line: 100,
                     space: 200,
-                    offset: 0,
                     endcap: 20,
                 },
                 AbstractLayer {
                     dir: RoutingDir::Vert,
                     line: 120,
                     space: 200,
-                    offset: 0,
                     endcap: 20,
                 },
                 AbstractLayer {
                     dir: RoutingDir::Horiz,
                     line: 200,
                     space: 400,
-                    offset: 0,
                     endcap: 40,
                 },
                 AbstractLayer {
                     dir: RoutingDir::Vert,
                     line: 200,
                     space: 400,
-                    offset: 0,
                     endcap: 50,
                 },
             ],

--- a/pdks/sky130pdk/src/atoll/mod.rs
+++ b/pdks/sky130pdk/src/atoll/mod.rs
@@ -38,7 +38,6 @@ impl Sky130Layers {
                         },
                         line: 170,
                         space: 260,
-                        offset: 85,
                         endcap: 85,
                     },
                 },
@@ -48,8 +47,7 @@ impl Sky130Layers {
                         dir: RoutingDir::Horiz,
                         line: 260,
                         space: 140,
-                        offset: 130,
-                        endcap: 100,
+                        endcap: 85,
                     },
                 },
                 PdkLayer {
@@ -58,7 +56,6 @@ impl Sky130Layers {
                         dir: RoutingDir::Vert,
                         line: 400,
                         space: 460,
-                        offset: 150,
                         endcap: 130,
                     },
                 },
@@ -68,8 +65,7 @@ impl Sky130Layers {
                         dir: RoutingDir::Horiz,
                         line: 400,
                         space: 400,
-                        offset: 200,
-                        endcap: 150,
+                        endcap: 200,
                     },
                 },
                 PdkLayer {
@@ -78,7 +74,6 @@ impl Sky130Layers {
                         dir: RoutingDir::Vert,
                         line: 1_200,
                         space: 950,
-                        offset: 600,
                         endcap: 200,
                     },
                 },
@@ -88,7 +83,6 @@ impl Sky130Layers {
                         dir: RoutingDir::Horiz,
                         line: 1_800,
                         space: 1_800,
-                        offset: 900,
                         endcap: 600,
                     },
                 },
@@ -240,7 +234,7 @@ impl MosTile {
         let stack = cell.ctx.get_installation::<LayerStack<PdkLayer>>().unwrap();
         let grid = RoutingGrid::new((*stack).clone(), 0..2);
 
-        let tracks = (0..self.nf + 1)
+        let tracks = (1..self.nf + 2)
             .map(|i| {
                 let span = grid.track_span(0, i);
                 Rect::from_spans(span, Span::new(-10, self.w + 10))


### PR DESCRIPTION
Remove the offset field from `AbstractLayer`, making
all tracks be centered at the origin.
