### PR TITLE
feat(spectre): add isource (current source)

### DIFF
--- a/tools/spectre/src/blocks.rs
+++ b/tools/spectre/src/blocks.rs
@@ -132,6 +132,8 @@ impl Schematic<Spectre> for DcVsource {
 }
 
 /// A current source.
+///
+/// Positive current is drawn from the `p` node and enters the `n` node.
 #[derive(Serialize, Deserialize, Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Isource {
     /// A dc current source.


### PR DESCRIPTION
Adds support for the Spectre isource component.
Positive current is drawn from the `p` terminal
and enters the `n` terminal.
