### PR TITLE
feat(spectre): support AC simulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2652,6 +2652,7 @@ dependencies = [
  "indexmap 2.2.5",
  "lazy_static",
  "ngspice",
+ "num",
  "rust_decimal",
  "rust_decimal_macros",
  "scir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a824f2aa7e75a0c98c5a504fceb80649e9c35265d44525b5f94de4771a395cd"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
  "getrandom",
  "once_cell",
@@ -30,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.7"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.7"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd2405b3ac1faab2990b74d728624cd9fd115651fcecc7c2d8daf01376275ba"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
 
 [[package]]
 name = "anstyle-parse"
@@ -120,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "approx"
@@ -188,7 +188,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -199,7 +199,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -208,7 +208,7 @@ version = "0.1.3"
 dependencies = [
  "ena",
  "grid",
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "num",
  "pathfinding",
  "rustc-hash",
@@ -308,9 +308,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
 name = "bitvec"
@@ -350,18 +350,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7aadb5b6ccbd078890f6d7003694e33816e6b784358f18e15e7e6d9f065a57cd"
 dependencies = [
  "once_cell",
- "proc-macro-crate 3.0.0",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
  "syn_derive",
 ]
 
 [[package]]
 name = "bstr"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
+checksum = "05efc5cfd9110c8416e471df0e96702d58690178e206e61b7173706673c93706"
 dependencies = [
  "memchr",
  "serde",
@@ -369,15 +369,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "bytecheck"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
 dependencies = [
  "bytecheck_derive",
  "ptr_meta",
@@ -386,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "bytecheck_derive"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ec4c6f261935ad534c0c22dbef2201b45918860eb1c574b972bd213a76af61"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -444,12 +444,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
-]
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
 name = "cfg-if"
@@ -465,9 +462,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
-version = "0.4.31"
+version = "0.4.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2c685bad3eb3d45a01354cedb7d5faa66194d1d58ba6e267a8de788f79db38"
+checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -475,14 +472,14 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
 name = "chrono-tz"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d7b79e99bfaa0d47da0687c43aa3b7381938a62ad3a6498599039321f660b7"
+checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -502,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.16"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e54881c004cec7895b0068a0a954cd5d62da01aef83fa35b1e594497bf5445"
+checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -512,33 +509,33 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.16"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cb82d7f531603d2fd1f507441cdd35184fa81beff7bd489570de7f773460bb"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.0",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "codegen"
@@ -546,7 +543,7 @@ version = "0.8.1"
 dependencies = [
  "arcstr",
  "convert_case 0.6.0",
- "darling 0.20.3",
+ "darling 0.20.8",
  "examples",
  "proc-macro-crate 1.3.1",
  "proc-macro-error",
@@ -559,7 +556,7 @@ dependencies = [
  "spectre",
  "spice",
  "substrate",
- "syn 2.0.48",
+ "syn 2.0.52",
  "type_dispatch",
 ]
 
@@ -615,9 +612,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -669,12 +666,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.3"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
 dependencies = [
- "darling_core 0.20.3",
- "darling_macro 0.20.3",
+ "darling_core 0.20.8",
+ "darling_macro 0.20.8",
 ]
 
 [[package]]
@@ -687,22 +684,22 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 1.0.109",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.20.3"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
- "syn 2.0.48",
+ "strsim 0.10.0",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -718,13 +715,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.3"
+version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
 dependencies = [
- "darling_core 0.20.3",
+ "darling_core 0.20.8",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -736,7 +733,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "semver",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -785,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "deunicode"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae2a35373c5c74340b79ae6780b498b2b183915ec5dacf263aac5a099bf485a"
+checksum = "b6e854126756c496b8c81dec88f9a706b15b875c5849d4097a3854476b9fdf94"
 
 [[package]]
 name = "diagnostics"
@@ -825,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "ena"
@@ -850,12 +847,12 @@ name = "enumify_macros"
 version = "0.1.0"
 dependencies = [
  "convert_case 0.6.0",
- "darling 0.20.3",
+ "darling 0.20.8",
  "proc-macro-crate 1.3.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
  "type_dispatch",
 ]
 
@@ -891,7 +888,7 @@ dependencies = [
  "spectre",
  "spice",
  "substrate",
- "syn 2.0.48",
+ "syn 2.0.52",
  "textwrap",
 ]
 
@@ -985,7 +982,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1060,12 +1057,12 @@ dependencies = [
 name = "geometry_macros"
 version = "0.0.1"
 dependencies = [
- "darling 0.20.3",
+ "darling 0.20.8",
  "proc-macro-crate 1.3.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
  "type_dispatch",
 ]
 
@@ -1095,7 +1092,7 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.6",
  "regex-syntax 0.8.2",
 ]
 
@@ -1121,9 +1118,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b553656127a00601c8ae5590fcfdc118e4083a7924b6cf4ffc1ea4b99dc429d7"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -1131,7 +1128,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -1144,7 +1141,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash 0.7.7",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -1153,7 +1150,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.7",
+ "ahash 0.8.11",
  "allocator-api2",
 ]
 
@@ -1174,9 +1171,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -1195,9 +1192,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -1274,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.59"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6a67363e2aa4443928ce15e57ebae94fd8949958fd1223c4cfc0cd473ad7539"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1311,7 +1308,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.6",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -1340,9 +1337,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -1384,9 +1381,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.67"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1405,9 +1402,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.152"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libm"
@@ -1428,15 +1425,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "matchers"
@@ -1473,18 +1470,18 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "wasi",
@@ -1503,7 +1500,7 @@ version = "0.3.1"
 dependencies = [
  "arcstr",
  "cache",
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "lazy_static",
  "nutlex",
  "rust_decimal",
@@ -1561,43 +1558,44 @@ dependencies = [
  "autocfg",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
 name = "num-complex"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba157ca0885411de85d6ca030ba7e2a83a28636056c7c699b07c8b6f7383214"
+checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
 dependencies = [
  "num-traits",
+ "serde",
 ]
 
 [[package]]
 name = "num-derive"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb77679af88f8b125209d354a202862602672222e7f2313fdd6dc349bad4712"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+checksum = "d869c01cc0c455284163fd0092f1f93835385ccab5a98a0dcc497b2f8bf055a9"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1614,13 +1612,14 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
 ]
@@ -1723,13 +1722,13 @@ dependencies = [
 
 [[package]]
 name = "pathfinding"
-version = "4.8.1"
+version = "4.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b425bfb8934d227558811f4b8c94d6fe64c9069c1387deed0f586bc418271b2"
+checksum = "f0a21c30f03223ae4a4c892f077b3189133689b8a659a84372f8422384ce94c9"
 dependencies = [
  "deprecate-until",
  "fixedbitset",
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "integer-sqrt",
  "num-traits",
  "rustc-hash",
@@ -1748,9 +1747,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.6"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f200d8d83c44a45b21764d1916299752ca035d15ecd46faca3e9a2a2bf6ad06"
+checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -1759,9 +1758,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.6"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcd6ab1236bbdb3a49027e920e693192ebfe8913f6d60e294de57463a493cfde"
+checksum = "b0d24f72393fd16ab6ac5738bc33cdb6a9aa73f8b902e8fe29cf4e67d7dd1026"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1769,22 +1768,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.6"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a31940305ffc96863a735bef7c7994a00b325a7138fdbc5bda0f1a0476d3275"
+checksum = "fdc17e2a6c7d0a492f0158d7a4bd66cc17280308bbaff78d5bef566dca35ab80"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.6"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7ff62f5259e53b78d1af898941cdcdccfae7385cf7d793a6e55de5d05bb4b7d"
+checksum = "934cd7631c050f4674352a6e835d5f6711ffbfb9345c2fc0107155ac495ae293"
 dependencies = [
  "once_cell",
  "pest",
@@ -1798,7 +1797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
 ]
 
 [[package]]
@@ -1841,22 +1840,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1873,9 +1872,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "ppv-lite86"
@@ -1890,7 +1889,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -1905,11 +1904,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.0.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b2685dd208a3771337d8d386a89840f0f43cd68be8dae90a5f8c2384effc9cd"
+checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
 dependencies = [
- "toml_edit 0.21.0",
+ "toml_edit 0.21.1",
 ]
 
 [[package]]
@@ -1938,9 +1937,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.76"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1972,7 +1971,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.48",
+ "syn 2.0.52",
  "tempfile",
  "which",
 ]
@@ -1987,7 +1986,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2001,12 +2000,13 @@ dependencies = [
 
 [[package]]
 name = "psfparser"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce3c3dcd9cd6b1aed035069d4b1961de1f0a4eff12d79c068da043654cce663"
+checksum = "aded49e0746579b54e939471e8b3f40e835cd1a954f257d9af130a31151d1e04"
 dependencies = [
  "anyhow",
  "float_eq",
+ "num",
  "pest",
  "pest_derive",
 ]
@@ -2077,23 +2077,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.3",
+ "regex-automata 0.4.6",
  "regex-syntax 0.8.2",
 ]
 
@@ -2108,9 +2099,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2131,18 +2122,18 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "rend"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2571463863a6bd50c32f94402933f03457a3fbaf697a707c5be741e459f08fd"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
 ]
 
 [[package]]
 name = "rkyv"
-version = "0.7.43"
+version = "0.7.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527a97cdfef66f65998b5f3b637c26f5a5ec09cc52a3f9932313ac645f4190f5"
+checksum = "5cba464629b3394fc4dbc6f940ff8f5b4ff5c7aef40f29166fd4ad12acbc99c0"
 dependencies = [
  "bitvec",
  "bytecheck",
@@ -2158,9 +2149,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.43"
+version = "0.7.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c462a1328c8e67e4d6dbad1eb0355dd43e8ab432c6e227a43657f16ade5033"
+checksum = "a7dddfff8de25e6f62b9d64e6e432bf1c6736c57d20323e15ee10435fbda7c65"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2173,7 +2164,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78046161564f5e7cd9008aff3b2990b3850dc8e0349119b98e8f251e099f24d"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -2183,9 +2174,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.33.1"
+version = "1.34.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06676aec5ccb8fc1da723cc8c0f9a46549f21ebb8753d3915c6c41db1e7f1dc4"
+checksum = "b39449a79f45e8da28c57c341891b69a183044b29518bb8f86dbac9df60bb7df"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -2199,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal_macros"
-version = "1.33.1"
+version = "1.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e43721f4ef7060ebc2c3ede757733209564ca8207f47674181bcd425dd76945"
+checksum = "e418701588729bef95e7a655f2b483ad64bb97c46e8e79fde83efd92aaab6d82"
 dependencies = [
  "quote",
  "rust_decimal",
@@ -2230,11 +2221,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.30"
+version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2249,9 +2240,9 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "same-file"
@@ -2269,7 +2260,7 @@ dependencies = [
  "arcstr",
  "diagnostics",
  "enumify",
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "rust_decimal",
  "rust_decimal_macros",
  "serde",
@@ -2288,35 +2279,35 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "semver"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97ed7a9823b74f99c7742f5336af7be5ecd3eeafcb1507d1fa93347b1d589b0"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.111"
+version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176e46fa42316f18edd598015a5166857fc835ec732f5215eac6b7bdbf0a84f4"
+checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
 dependencies = [
  "itoa",
  "ryu",
@@ -2334,11 +2325,11 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.30"
+version = "0.9.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1bf28c79a99f70ee1f1d83d10c875d2e70618417fda01ad1785e027579d9d38"
+checksum = "8fd075d994154d4a774f95b51fb96bdc2832b0ea48425c92546073816cda1f2f"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "itoa",
  "ryu",
  "serde",
@@ -2392,7 +2383,7 @@ version = "0.8.1"
 dependencies = [
  "arcstr",
  "atoll",
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "ngspice",
  "paste",
  "rust_decimal",
@@ -2435,9 +2426,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.12.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2593d31f82ead8df961d8bd23a64c2ccf2eb5dd34b0a34bfb4dd54011c72009e"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "smawk"
@@ -2447,12 +2438,12 @@ checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2463,6 +2454,7 @@ dependencies = [
  "cache",
  "itertools",
  "lazy_static",
+ "num",
  "psfparser",
  "regex",
  "rust_decimal",
@@ -2503,6 +2495,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
 name = "substrate"
 version = "0.8.1"
 dependencies = [
@@ -2521,7 +2519,7 @@ dependencies = [
  "gds",
  "geometry",
  "impl-trait-for-tuples",
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "num",
  "once_cell",
  "pathtree",
@@ -2553,9 +2551,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2571,7 +2569,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2588,13 +2586,12 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.9.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -2623,9 +2620,9 @@ dependencies = [
 
 [[package]]
 name = "test-log"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6159ab4116165c99fc88cce31f99fa2c9dbe08d3691cb38da02fc3b45f357d2b"
+checksum = "7b319995299c65d522680decf80f2c108d85b861d81dfe340a10d16cee29d9e6"
 dependencies = [
  "test-log-macros",
  "tracing-subscriber",
@@ -2633,13 +2630,13 @@ dependencies = [
 
 [[package]]
 name = "test-log-macros"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba277e77219e9eea169e8508942db1bf5d8a41ff2db9b20aab5a5aadc9fa25d"
+checksum = "c8f546451eaa38373f549093fe9fd05e7d2bade739e2ddf834b9968621d60107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2652,7 +2649,7 @@ dependencies = [
  "atoll",
  "cache",
  "geometry",
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "lazy_static",
  "ngspice",
  "rust_decimal",
@@ -2670,9 +2667,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 dependencies = [
  "smawk",
  "unicode-linebreak",
@@ -2681,29 +2678,29 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2726,9 +2723,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.35.1"
+version = "1.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
+checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2760,7 +2757,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2801,14 +2798,14 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a195ec8c9da26928f773888e0742ca3ca1040c6cd859c919c9f59c1954ab35"
+checksum = "af06656561d28735e9c1cd63dfd57132c8155426aa6af24f36a00a351f88c48e"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.21.0",
+ "toml_edit 0.22.7",
 ]
 
 [[package]]
@@ -2826,9 +2823,9 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
@@ -2837,22 +2834,33 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34d383cd00a163b4a5b85053df514d45bc330f6de7737edfe0a93311d1eaa03"
+checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.2.5",
+ "toml_datetime",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18769cd1cec395d70860ceb4d932812a0b4d06b1a4bb336745a4d21b9496e992"
+dependencies = [
+ "indexmap 2.2.5",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.6.5",
 ]
 
 [[package]]
@@ -2892,7 +2900,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2946,7 +2954,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]
 
 [[package]]
@@ -2998,11 +3006,11 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 name = "type_dispatch"
 version = "0.3.0"
 dependencies = [
- "darling 0.20.3",
+ "darling 0.20.8",
  "duplicate",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
  "type_dispatch_macros",
 ]
 
@@ -3010,13 +3018,13 @@ dependencies = [
 name = "type_dispatch_macros"
 version = "0.3.0"
 dependencies = [
- "darling 0.20.3",
+ "darling 0.20.8",
  "itertools",
  "proc-macro-crate 1.3.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
  "type_dispatch",
 ]
 
@@ -3105,9 +3113,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
+checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
@@ -3137,9 +3145,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 
 [[package]]
 name = "valuable"
@@ -3161,9 +3169,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -3186,9 +3194,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3196,24 +3204,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3221,22 +3229,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.90"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "which"
@@ -3287,7 +3295,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -3305,7 +3313,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -3325,17 +3333,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -3346,9 +3354,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3358,9 +3366,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3370,9 +3378,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3382,9 +3390,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3394,9 +3402,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3406,9 +3414,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3418,15 +3426,24 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"
-version = "0.5.34"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7cf47b659b318dccbd69cc4797a39ae128f533dce7902a1096044d1967b9c16"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
 dependencies = [
  "memchr",
 ]
@@ -3457,5 +3474,5 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.52",
 ]

--- a/substrate/Cargo.toml
+++ b/substrate/Cargo.toml
@@ -20,7 +20,7 @@ derive_builder = "0.12"
 slotmap = "1"
 downcast-rs = "1"
 indexmap = { version = "2", features = ["serde"] }
-num = "0.4"
+num = { version = "0.4", features = ["serde"] }
 
 config = { version = "0.2.5", registry = "substrate", path = "../config" }
 examples = { version = "0.5.1", registry = "substrate", path = "../docs/examples" }

--- a/substrate/src/simulation/data.rs
+++ b/substrate/src/simulation/data.rs
@@ -17,6 +17,27 @@ pub trait FromSaved<S: Simulator, A: Analysis> {
     fn from_saved(output: &<A as Analysis>::Output, key: &Self::SavedKey) -> Self;
 }
 
+impl<S, A1, A2, O1, O2> FromSaved<S, (A1, A2)> for (O1, O2)
+where
+    S: Simulator,
+    A1: Analysis,
+    A2: Analysis,
+    O1: FromSaved<S, A1>,
+    O2: FromSaved<S, A2>,
+    (A1, A2): Analysis<Output = (A1::Output, A2::Output)>,
+{
+    type SavedKey = (
+        <O1 as FromSaved<S, A1>>::SavedKey,
+        <O2 as FromSaved<S, A2>>::SavedKey,
+    );
+
+    fn from_saved(output: &<(A1, A2) as Analysis>::Output, key: &Self::SavedKey) -> Self {
+        let o1 = <O1 as FromSaved<S, A1>>::from_saved(&output.0, &key.0);
+        let o2 = <O2 as FromSaved<S, A2>>::from_saved(&output.1, &key.1);
+        (o1, o2)
+    }
+}
+
 /// Gets the [`FromSaved::SavedKey`] corresponding to type `T`.
 pub type SavedKey<S, A, T> = <T as FromSaved<S, A>>::SavedKey;
 

--- a/substrate/src/simulation/data.rs
+++ b/substrate/src/simulation/data.rs
@@ -91,3 +91,44 @@ pub mod tran {
         }
     }
 }
+
+/// AC data definitions.
+pub mod ac {
+    use num::complex::Complex64;
+    use serde::{Deserialize, Serialize};
+    use std::ops::Deref;
+    use std::sync::Arc;
+
+    /// A series of voltage vs frequency measurements from an AC simulation.
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    pub struct Voltage(pub Arc<Vec<Complex64>>);
+
+    impl Deref for Voltage {
+        type Target = Vec<Complex64>;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    /// A series of current vs frequency measurements from an AC simulation.
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    pub struct Current(pub Arc<Vec<Complex64>>);
+
+    impl Deref for Current {
+        type Target = Vec<Complex64>;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    /// The frequency points associated with an AC simulation.
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    pub struct Freq(pub Arc<Vec<f64>>);
+
+    impl Deref for Freq {
+        type Target = Vec<f64>;
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+}

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -26,6 +26,7 @@ spice = { version = "0.7.1", registry = "substrate", path = "../libs/spice" }
 spectre = { version = "0.9.1", registry = "substrate", path = "../tools/spectre" }
 ngspice = { version = "0.3.1", registry = "substrate", path = "../tools/ngspice" }
 sky130pdk = { version = "0.8.1", registry = "substrate", path = "../pdks/sky130pdk" }
+num = { version = "0.4.1", features = ["serde"] }
 
 [features]
 spectre = []

--- a/tests/src/shared/rc/mod.rs
+++ b/tests/src/shared/rc/mod.rs
@@ -1,15 +1,18 @@
+use num::complex::Complex64;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use serde::{Deserialize, Serialize};
+use spectre::analysis::ac::{Ac, Sweep};
 use spectre::analysis::tran::Tran;
-use spectre::{Options, Spectre};
+use spectre::blocks::{AcSource, Isource};
+use spectre::{ErrPreset, Options, Spectre};
 use substrate::block::Block;
 use substrate::io::schematic::{HardwareType, Node};
 use substrate::io::Signal;
 use substrate::io::TestbenchIo;
 use substrate::schematic::primitives::{Capacitor, Resistor};
 use substrate::schematic::{Cell, CellBuilder, ExportsNestedData, Schematic};
-use substrate::simulation::data::{tran, FromSaved, Save, SaveTb};
+use substrate::simulation::data::{ac, tran, FromSaved, Save, SaveTb};
 use substrate::simulation::options::ic;
 use substrate::simulation::options::ic::InitialCondition;
 use substrate::simulation::{SimulationContext, Simulator, Testbench};
@@ -49,22 +52,33 @@ impl Schematic<Spectre> for RcTb {
         cell.connect(c.io().p, vout);
         cell.connect(c.io().n, io.vss);
 
+        let isource = cell.instantiate(Isource::ac(AcSource {
+            dc: dec!(0),
+            mag: dec!(1),
+            phase: dec!(0),
+        }));
+        cell.connect(isource.io().p, vout);
+        cell.connect(isource.io().n, io.vss);
+
         Ok(vout)
     }
 }
 
-impl SaveTb<Spectre, Tran, tran::Voltage> for RcTb {
+impl SaveTb<Spectre, (Tran, Ac), (tran::Voltage, ac::Voltage)> for RcTb {
     fn save_tb(
         ctx: &SimulationContext<Spectre>,
-        to_save: &Cell<Self>,
+        cell: &Cell<Self>,
         opts: &mut <Spectre as Simulator>::Options,
-    ) -> <tran::Voltage as FromSaved<Spectre, Tran>>::SavedKey {
-        tran::Voltage::save(ctx, to_save.data(), opts)
+    ) -> <(tran::Voltage, ac::Voltage) as FromSaved<Spectre, (Tran, Ac)>>::SavedKey {
+        (
+            tran::Voltage::save(ctx, cell.data(), opts),
+            ac::Voltage::save(ctx, cell.data(), opts),
+        )
     }
 }
 
 impl Testbench<Spectre> for RcTb {
-    type Output = (f64, f64);
+    type Output = (f64, f64, Complex64);
     fn run(&self, sim: substrate::simulation::SimController<Spectre, Self>) -> Self::Output {
         let mut opts = Options::default();
         sim.set_option(
@@ -74,18 +88,26 @@ impl Testbench<Spectre> for RcTb {
             },
             &mut opts,
         );
-        let vout: tran::Voltage = sim
+        let (tran_vout, ac_vout) = sim
             .simulate(
                 opts,
-                Tran {
-                    stop: dec!(10e-6),
-                    ..Default::default()
-                },
+                (
+                    Tran {
+                        stop: dec!(10e-6),
+                        ..Default::default()
+                    },
+                    Ac {
+                        start: dec!(1e6),
+                        stop: dec!(1e7),
+                        sweep: Sweep::Linear(11),
+                        errpreset: Some(ErrPreset::Conservative),
+                    },
+                ),
             )
             .unwrap();
 
-        let first = vout.first().unwrap();
-        let last = vout.last().unwrap();
-        (*first, *last)
+        let first = tran_vout.first().unwrap();
+        let last = tran_vout.last().unwrap();
+        (*first, *last, ac_vout[2])
     }
 }

--- a/tests/src/shared/rc/mod.rs
+++ b/tests/src/shared/rc/mod.rs
@@ -98,8 +98,8 @@ impl Testbench<Spectre> for RcTb {
                     },
                     Ac {
                         start: dec!(1e6),
-                        stop: dec!(1e7),
-                        sweep: Sweep::Linear(11),
+                        stop: dec!(2e6),
+                        sweep: Sweep::Linear(10),
                         errpreset: Some(ErrPreset::Conservative),
                     },
                 ),

--- a/tests/src/sim/spectre.rs
+++ b/tests/src/sim/spectre.rs
@@ -449,6 +449,6 @@ fn spectre_rc_zin_ac() {
     let (_, _, z) = ctx
         .simulate(crate::shared::rc::RcTb::new(dec!(0)), sim_dir)
         .unwrap();
-    assert_relative_eq!(z.re, 6.896551724137931);
-    assert_relative_eq!(z.im, -82.75862068965517);
+    assert_relative_eq!(z.re, 17.286407017773225);
+    assert_relative_eq!(z.im, -130.3364383055986);
 }

--- a/tests/src/sim/spectre.rs
+++ b/tests/src/sim/spectre.rs
@@ -34,7 +34,6 @@ use crate::shared::pdk::sky130_commercial_ctx;
 use crate::shared::vdivider::tb::{VdividerArrayTb, VdividerDuplicateSubcktTb};
 use crate::{paths::get_path, shared::vdivider::tb::VdividerTb};
 use substrate::schematic::primitives::{RawInstance, Resistor};
-use substrate::simulation::data::tran::{Current, Voltage};
 
 #[test]
 fn vdivider_tran() {
@@ -256,7 +255,7 @@ fn spectre_can_include_sections() {
             ctx: &SimulationContext<Spectre>,
             cell: &Cell<Self>,
             opts: &mut <Spectre as Simulator>::Options,
-        ) -> <Voltage as FromSaved<Spectre, Tran>>::SavedKey {
+        ) -> <tran::Voltage as FromSaved<Spectre, Tran>>::SavedKey {
             tran::Voltage::save(ctx, cell.data().io().n, opts)
         }
     }
@@ -392,7 +391,7 @@ fn spectre_can_save_paths_with_flattened_instances() {
             ctx: &SimulationContext<Spectre>,
             cell: &Cell<Self>,
             opts: &mut <Spectre as Simulator>::Options,
-        ) -> <Current as FromSaved<Spectre, Tran>>::SavedKey {
+        ) -> <tran::Current as FromSaved<Spectre, Tran>>::SavedKey {
             tran::Current::save(ctx, cell.data().io().p, opts)
         }
     }
@@ -430,13 +429,26 @@ fn spectre_initial_condition() {
     let sim_dir = get_path(test_name, "sim/");
     let ctx = sky130_commercial_ctx();
 
-    let (first, _) = ctx
+    let (first, _, _) = ctx
         .simulate(crate::shared::rc::RcTb::new(dec!(1.4)), &sim_dir)
         .unwrap();
     assert_relative_eq!(first, 1.4);
 
-    let (first, _) = ctx
+    let (first, _, _) = ctx
         .simulate(crate::shared::rc::RcTb::new(dec!(2.1)), sim_dir)
         .unwrap();
     assert_relative_eq!(first, 2.1);
+}
+
+#[test]
+fn spectre_rc_zin_ac() {
+    let test_name = "spectre_rc_zin_ac";
+    let sim_dir = get_path(test_name, "sim/");
+    let ctx = sky130_commercial_ctx();
+
+    let (_, _, z) = ctx
+        .simulate(crate::shared::rc::RcTb::new(dec!(0)), sim_dir)
+        .unwrap();
+    assert_relative_eq!(z.re, 6.896551724137931);
+    assert_relative_eq!(z.im, -82.75862068965517);
 }

--- a/tests/src/sim/spectre.rs
+++ b/tests/src/sim/spectre.rs
@@ -449,6 +449,6 @@ fn spectre_rc_zin_ac() {
     let (_, _, z) = ctx
         .simulate(crate::shared::rc::RcTb::new(dec!(0)), sim_dir)
         .unwrap();
-    assert_relative_eq!(z.re, 17.286407017773225);
-    assert_relative_eq!(z.im, -130.3364383055986);
+    assert_relative_eq!(z.re, -17.286407017773225);
+    assert_relative_eq!(z.im, 130.3364383055986);
 }

--- a/tools/spectre/Cargo.toml
+++ b/tools/spectre/Cargo.toml
@@ -13,11 +13,12 @@ lazy_static = "1"
 serde = { version = "1", features = ["derive"] }
 tracing = "0.1"
 itertools = "0.11"
-psfparser = "0.1.1"
+psfparser = "0.1.2"
 
 cache = { version = "0.5.0", registry = "substrate", path = "../../libs/cache" }
 scir = { version = "0.7.0", registry = "substrate", path = "../../libs/scir" }
 substrate = { version = "0.8.1", registry = "substrate", path = "../../substrate" }
 spice = { version = "0.7.1", registry = "substrate", path = "../../libs/spice" }
 regex = "1.10.2"
+num = { version = "0.4.1", features = ["serde"] }
 

--- a/tools/spectre/src/analysis/ac.rs
+++ b/tools/spectre/src/analysis/ac.rs
@@ -1,0 +1,311 @@
+//! Spectre AC small-signal analysis options and data structures.
+
+use crate::{ErrPreset, SimSignal, Spectre};
+use arcstr::ArcStr;
+use num::complex::Complex64;
+use num::Zero;
+use rust_decimal::Decimal;
+use scir::{NamedSliceOne, SliceOnePath};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+use substrate::io::schematic::{NestedNode, NestedTerminal, NodePath, TerminalPath};
+use substrate::schematic::conv::ConvertedNodePath;
+use substrate::simulation::data::{ac, FromSaved, Save};
+use substrate::simulation::{Analysis, SimulationContext, Simulator, SupportedBy};
+use substrate::type_dispatch::impl_dispatch;
+
+/// Sweep kinds.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum Sweep {
+    /// Linear sweep with the given number of points.
+    Linear(usize),
+    /// Logarithmic sweep with the given number of points.
+    Logarithmic(usize),
+    /// Logarithmic sweep with the given number of points **per decade**.
+    Decade(usize),
+}
+
+/// An AC analysis.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Ac {
+    /// Start frequency (Hz).
+    ///
+    /// Defaults to 0.
+    pub start: Decimal,
+    /// Stop frequency (Hz).
+    pub stop: Decimal,
+    /// The sweep kind and number of points.
+    pub sweep: Sweep,
+
+    /// The error preset.
+    pub errpreset: Option<ErrPreset>,
+}
+
+/// The result of an AC analysis.
+#[derive(Debug, Clone)]
+pub struct Output {
+    /// The frequency points of the AC simulation.
+    pub freq: Arc<Vec<f64>>,
+    /// A map from signal name to values.
+    pub raw_values: HashMap<ArcStr, Arc<Vec<Complex64>>>,
+    /// A map from a save ID to a raw value identifier.
+    pub(crate) saved_values: HashMap<u64, ArcStr>,
+}
+
+impl FromSaved<Spectre, Ac> for Output {
+    type SavedKey = ();
+
+    fn from_saved(output: &<Ac as Analysis>::Output, _key: &Self::SavedKey) -> Self {
+        (*output).clone()
+    }
+}
+
+impl Save<Spectre, Ac, ()> for Output {
+    fn save(
+        _ctx: &SimulationContext<Spectre>,
+        _to_save: (),
+        _opts: &mut <Spectre as Simulator>::Options,
+    ) -> Self::SavedKey {
+    }
+}
+
+impl FromSaved<Spectre, Ac> for ac::Freq {
+    type SavedKey = ();
+    fn from_saved(output: &<Ac as Analysis>::Output, _key: &Self::SavedKey) -> Self {
+        ac::Freq(output.freq.clone())
+    }
+}
+
+impl Save<Spectre, Ac, ()> for ac::Freq {
+    fn save(
+        _ctx: &SimulationContext<Spectre>,
+        _to_save: (),
+        _opts: &mut <Spectre as Simulator>::Options,
+    ) -> Self::SavedKey {
+    }
+}
+
+/// An identifier for a saved AC voltage.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VoltageSavedKey(pub(crate) u64);
+
+impl FromSaved<Spectre, Ac> for ac::Voltage {
+    type SavedKey = VoltageSavedKey;
+    fn from_saved(output: &<Ac as Analysis>::Output, key: &Self::SavedKey) -> Self {
+        ac::Voltage(
+            output
+                .raw_values
+                .get(output.saved_values.get(&key.0).unwrap())
+                .unwrap()
+                .clone(),
+        )
+    }
+}
+
+#[impl_dispatch({&str; &String; ArcStr; String; SimSignal})]
+impl<T> Save<Spectre, Ac, T> for ac::Voltage {
+    fn save(
+        _ctx: &SimulationContext<Spectre>,
+        to_save: T,
+        opts: &mut <Spectre as Simulator>::Options,
+    ) -> Self::SavedKey {
+        opts.save_ac_voltage(to_save)
+    }
+}
+
+impl Save<Spectre, Ac, &SliceOnePath> for ac::Voltage {
+    fn save(
+        _ctx: &SimulationContext<Spectre>,
+        to_save: &SliceOnePath,
+        opts: &mut <Spectre as Simulator>::Options,
+    ) -> Self::SavedKey {
+        opts.save_ac_voltage(SimSignal::ScirVoltage(to_save.clone()))
+    }
+}
+
+impl Save<Spectre, Ac, &ConvertedNodePath> for ac::Voltage {
+    fn save(
+        ctx: &SimulationContext<Spectre>,
+        to_save: &ConvertedNodePath,
+        opts: &mut <Spectre as Simulator>::Options,
+    ) -> Self::SavedKey {
+        Self::save(
+            ctx,
+            match to_save {
+                ConvertedNodePath::Cell(path) => path.clone(),
+                ConvertedNodePath::Primitive {
+                    instances, port, ..
+                } => SliceOnePath::new(instances.clone(), NamedSliceOne::new(port.clone())),
+            },
+            opts,
+        )
+    }
+}
+
+impl Save<Spectre, Ac, &NodePath> for ac::Voltage {
+    fn save(
+        ctx: &SimulationContext<Spectre>,
+        to_save: &NodePath,
+        opts: &mut <Spectre as Simulator>::Options,
+    ) -> Self::SavedKey {
+        Self::save(ctx, ctx.lib.convert_node_path(to_save).unwrap(), opts)
+    }
+}
+
+#[impl_dispatch({SliceOnePath; ConvertedNodePath; NodePath})]
+impl<T> Save<Spectre, Ac, T> for ac::Voltage {
+    fn save(
+        ctx: &SimulationContext<Spectre>,
+        to_save: T,
+        opts: &mut <Spectre as Simulator>::Options,
+    ) -> Self::SavedKey {
+        Self::save(ctx, &to_save, opts)
+    }
+}
+
+#[impl_dispatch({NestedNode; &NestedNode; NestedTerminal; &NestedTerminal})]
+impl<T> Save<Spectre, Ac, T> for ac::Voltage {
+    fn save(
+        ctx: &SimulationContext<Spectre>,
+        to_save: T,
+        opts: &mut <Spectre as Simulator>::Options,
+    ) -> Self::SavedKey {
+        Self::save(ctx, to_save.path(), opts)
+    }
+}
+
+#[impl_dispatch({TerminalPath; &TerminalPath})]
+impl<T> Save<Spectre, Ac, T> for ac::Voltage {
+    fn save(
+        ctx: &SimulationContext<Spectre>,
+        to_save: T,
+        opts: &mut <Spectre as Simulator>::Options,
+    ) -> Self::SavedKey {
+        Self::save(ctx, to_save.as_ref(), opts)
+    }
+}
+
+/// An identifier for a saved AC current.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CurrentSavedKey(pub(crate) Vec<u64>);
+
+impl FromSaved<Spectre, Ac> for ac::Current {
+    type SavedKey = CurrentSavedKey;
+    fn from_saved(output: &<Ac as Analysis>::Output, key: &Self::SavedKey) -> Self {
+        let currents: Vec<Arc<Vec<Complex64>>> = key
+            .0
+            .iter()
+            .map(|key| {
+                output
+                    .raw_values
+                    .get(output.saved_values.get(key).unwrap())
+                    .unwrap()
+                    .clone()
+            })
+            .collect();
+
+        let mut total_current = vec![Complex64::zero(); output.freq.len()];
+        for ac_current in currents {
+            for (i, current) in ac_current.iter().enumerate() {
+                total_current[i] += *current;
+            }
+        }
+        ac::Current(Arc::new(total_current))
+    }
+}
+
+#[impl_dispatch({&str; &String; ArcStr; String; SimSignal})]
+impl<T> Save<Spectre, Ac, T> for ac::Current {
+    fn save(
+        _ctx: &SimulationContext<Spectre>,
+        to_save: T,
+        opts: &mut <Spectre as Simulator>::Options,
+    ) -> Self::SavedKey {
+        opts.save_ac_current(to_save)
+    }
+}
+
+impl Save<Spectre, Ac, &SliceOnePath> for ac::Current {
+    fn save(
+        _ctx: &SimulationContext<Spectre>,
+        to_save: &SliceOnePath,
+        opts: &mut <Spectre as Simulator>::Options,
+    ) -> Self::SavedKey {
+        opts.save_ac_current(SimSignal::ScirCurrent(to_save.clone()))
+    }
+}
+
+impl Save<Spectre, Ac, &ConvertedNodePath> for ac::Current {
+    fn save(
+        ctx: &SimulationContext<Spectre>,
+        to_save: &ConvertedNodePath,
+        opts: &mut <Spectre as Simulator>::Options,
+    ) -> Self::SavedKey {
+        Self::save(
+            ctx,
+            match to_save {
+                ConvertedNodePath::Cell(path) => path.clone(),
+                ConvertedNodePath::Primitive {
+                    instances, port, ..
+                } => SliceOnePath::new(instances.clone(), NamedSliceOne::new(port.clone())),
+            },
+            opts,
+        )
+    }
+}
+
+impl Save<Spectre, Ac, &TerminalPath> for ac::Current {
+    fn save(
+        ctx: &SimulationContext<Spectre>,
+        to_save: &TerminalPath,
+        opts: &mut <Spectre as Simulator>::Options,
+    ) -> Self::SavedKey {
+        CurrentSavedKey(
+            ctx.lib
+                .convert_terminal_path(to_save)
+                .unwrap()
+                .into_iter()
+                .flat_map(|path| Self::save(ctx, path, opts).0)
+                .collect(),
+        )
+    }
+}
+
+#[impl_dispatch({SliceOnePath; ConvertedNodePath; TerminalPath})]
+impl<T> Save<Spectre, Ac, T> for ac::Current {
+    fn save(
+        ctx: &SimulationContext<Spectre>,
+        to_save: T,
+        opts: &mut <Spectre as Simulator>::Options,
+    ) -> Self::SavedKey {
+        Self::save(ctx, &to_save, opts)
+    }
+}
+
+#[impl_dispatch({NestedTerminal; &NestedTerminal})]
+impl<T> Save<Spectre, Ac, T> for ac::Current {
+    fn save(
+        ctx: &SimulationContext<Spectre>,
+        to_save: T,
+        opts: &mut <Spectre as Simulator>::Options,
+    ) -> Self::SavedKey {
+        Self::save(ctx, to_save.path(), opts)
+    }
+}
+
+impl Analysis for Ac {
+    type Output = Output;
+}
+
+impl SupportedBy<Spectre> for Ac {
+    fn into_input(self, inputs: &mut Vec<<Spectre as Simulator>::Input>) {
+        inputs.push(self.into());
+    }
+    fn from_output(
+        outputs: &mut impl Iterator<Item = <Spectre as Simulator>::Output>,
+    ) -> <Self as Analysis>::Output {
+        let item = outputs.next().unwrap();
+        item.try_into().unwrap()
+    }
+}

--- a/tools/spectre/src/analysis/mod.rs
+++ b/tools/spectre/src/analysis/mod.rs
@@ -1,3 +1,4 @@
 //! Spectre analyses.
+pub mod ac;
 pub mod montecarlo;
 pub mod tran;


### PR DESCRIPTION
Support AC small-signal simulation in Spectre.
We assume that AC simulations always sweep over frequency,
not over device or model parameters.