### PR TITLE
feat(dspf): propagate nested nodes from DSPF instances

### DIFF
--- a/libs/spice/src/lib.rs
+++ b/libs/spice/src/lib.rs
@@ -81,6 +81,15 @@ impl Spice {
         conv: &NetlistLibConversion,
         path: &SliceOnePath,
     ) -> String {
+        Self::node_path_with_separator(lib, conv, path, ".")
+    }
+
+    fn node_path_with_separator(
+        lib: &Library<Spice>,
+        conv: &NetlistLibConversion,
+        path: &SliceOnePath,
+        sep: &str,
+    ) -> String {
         lib.convert_slice_one_path_with_conv(conv, path.clone(), |name, index| {
             if let Some(index) = index {
                 arcstr::format!("{}\\[{}\\]", name, index)
@@ -88,7 +97,7 @@ impl Spice {
                 name.into()
             }
         })
-        .join(".")
+        .join(sep)
     }
 }
 

--- a/libs/spice/src/lib.rs
+++ b/libs/spice/src/lib.rs
@@ -74,7 +74,7 @@ impl Spice {
         Spice::scir_cell_from_parsed(&parsed, cell_name)
     }
 
-    /// Converts a [`SliceOnePath`] to a Spectre path string corresponding to the associated
+    /// Converts a [`SliceOnePath`] to a Spice path string corresponding to the associated
     /// node voltage.
     pub fn node_voltage_path(
         lib: &Library<Spice>,
@@ -84,7 +84,9 @@ impl Spice {
         Self::node_path_with_separator(lib, conv, path, ".")
     }
 
-    fn node_path_with_separator(
+    /// Converts a [`SliceOnePath`] to a Spice path string corresponding to the associated
+    /// node voltage, using the given hierarchy separator.
+    pub fn node_path_with_separator(
         lib: &Library<Spice>,
         conv: &NetlistLibConversion,
         path: &SliceOnePath,

--- a/libs/spice/src/lib.rs
+++ b/libs/spice/src/lib.rs
@@ -7,7 +7,7 @@ use crate::parser::{ParsedSpice, Parser};
 use arcstr::ArcStr;
 use rust_decimal::Decimal;
 use scir::schema::{FromSchema, NoSchema, NoSchemaError, Schema};
-use scir::{Instance, Library, ParamValue};
+use scir::{Instance, Library, NetlistLibConversion, ParamValue, SliceOnePath};
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use substrate::block::Block;
@@ -72,6 +72,23 @@ impl Spice {
     ) -> substrate::schematic::ScirBinding<Spice> {
         let parsed = Parser::parse_file(path).unwrap();
         Spice::scir_cell_from_parsed(&parsed, cell_name)
+    }
+
+    /// Converts a [`SliceOnePath`] to a Spectre path string corresponding to the associated
+    /// node voltage.
+    pub fn node_voltage_path(
+        lib: &Library<Spice>,
+        conv: &NetlistLibConversion,
+        path: &SliceOnePath,
+    ) -> String {
+        lib.convert_slice_one_path_with_conv(conv, path.clone(), |name, index| {
+            if let Some(index) = index {
+                arcstr::format!("{}\\[{}\\]", name, index)
+            } else {
+                name.into()
+            }
+        })
+        .join(".")
     }
 }
 

--- a/libs/spice/src/lib.rs
+++ b/libs/spice/src/lib.rs
@@ -5,6 +5,7 @@ use crate::parser::conv::ScirConverter;
 use crate::parser::{ParsedSpice, Parser};
 
 use arcstr::ArcStr;
+use itertools::Itertools;
 use rust_decimal::Decimal;
 use scir::schema::{FromSchema, NoSchema, NoSchemaError, Schema};
 use scir::{Instance, Library, NetlistLibConversion, ParamValue, SliceOnePath};
@@ -93,14 +94,25 @@ impl Spice {
         prefix: &str,
         sep: &str,
     ) -> String {
-        lib.convert_slice_one_path_with_conv(conv, path.clone(), |name, index| {
+        let path = lib.convert_slice_one_path_with_conv(conv, path.clone(), |name, index| {
             if let Some(index) = index {
-                arcstr::format!("{}{}\\[{}\\]", prefix, name, index)
+                arcstr::format!("{}\\[{}\\]", name, index)
             } else {
-                arcstr::format!("{}{}", prefix, name)
+                name.clone()
             }
-        })
-        .join(sep)
+        });
+        let n = path.len();
+        path.iter()
+            .enumerate()
+            .map(|(i, elt)| {
+                if i + 1 == n {
+                    // Don't add a prefix to the last element.
+                    elt.clone()
+                } else {
+                    arcstr::format!("{}{}", prefix, elt)
+                }
+            })
+            .join(sep)
     }
 }
 

--- a/libs/spice/src/lib.rs
+++ b/libs/spice/src/lib.rs
@@ -81,22 +81,23 @@ impl Spice {
         conv: &NetlistLibConversion,
         path: &SliceOnePath,
     ) -> String {
-        Self::node_path_with_separator(lib, conv, path, ".")
+        Self::node_path_with_prefix_and_separator(lib, conv, path, "", ".")
     }
 
     /// Converts a [`SliceOnePath`] to a Spice path string corresponding to the associated
-    /// node voltage, using the given hierarchy separator.
-    pub fn node_path_with_separator(
+    /// node voltage, using the given instance prefix hierarchy separator.
+    pub fn node_path_with_prefix_and_separator(
         lib: &Library<Spice>,
         conv: &NetlistLibConversion,
         path: &SliceOnePath,
+        prefix: &str,
         sep: &str,
     ) -> String {
         lib.convert_slice_one_path_with_conv(conv, path.clone(), |name, index| {
             if let Some(index) = index {
-                arcstr::format!("{}\\[{}\\]", name, index)
+                arcstr::format!("{}{}\\[{}\\]", prefix, name, index)
             } else {
-                name.into()
+                arcstr::format!("{}{}", prefix, name)
             }
         })
         .join(sep)

--- a/substrate/src/schematic/mod.rs
+++ b/substrate/src/schematic/mod.rs
@@ -908,7 +908,8 @@ impl InstancePath {
         }
     }
 
-    pub(crate) fn prepend(&self, other: &Self) -> Self {
+    /// Prepend another path to this path.
+    pub fn prepend(&self, other: &Self) -> Self {
         if let Some(bot) = other.bot {
             assert_eq!(
                 bot, self.top,

--- a/substrate/src/schematic/mod.rs
+++ b/substrate/src/schematic/mod.rs
@@ -532,6 +532,11 @@ impl<T: ExportsNestedData> Cell<T> {
         self.nodes.nested_view(&self.path)
     }
 
+    /// Returns the raw data propagated by the cell's schematic generator.
+    pub fn raw_data(&self) -> &Arc<<T as ExportsNestedData>::NestedData> {
+        &self.nodes
+    }
+
     /// Returns this cell's IO.
     pub fn io(&self) -> NestedView<<T::Io as HardwareType>::Bundle> {
         self.io.nested_view(&self.path)

--- a/tools/spectre/src/analysis/tran.rs
+++ b/tools/spectre/src/analysis/tran.rs
@@ -1,6 +1,7 @@
 //! Spectre transient analysis options and data structures.
 
-use crate::{ErrPreset, SimSignal, Spectre};
+use crate::dspf::DspfNode;
+use crate::{ErrPreset, InstanceTail, SimSignal, Spectre};
 use arcstr::ArcStr;
 use rust_decimal::Decimal;
 use scir::{NamedSliceOne, SliceOnePath};
@@ -96,6 +97,23 @@ impl<T> Save<Spectre, Tran, T> for tran::Voltage {
         opts: &mut <Spectre as Simulator>::Options,
     ) -> Self::SavedKey {
         opts.save_tran_voltage(to_save)
+    }
+}
+
+impl Save<Spectre, Tran, DspfNode> for tran::Voltage {
+    fn save(
+        ctx: &SimulationContext<Spectre>,
+        to_save: DspfNode,
+        opts: &mut <Spectre as Simulator>::Options,
+    ) -> <Self as FromSaved<Spectre, Tran>>::SavedKey {
+        let itail = InstanceTail {
+            instance: ctx
+                .lib
+                .convert_instance_path(&to_save.dspf_instance)
+                .unwrap(),
+            tail: to_save.path.into(),
+        };
+        opts.save_tran_voltage(itail)
     }
 }
 

--- a/tools/spectre/src/dspf.rs
+++ b/tools/spectre/src/dspf.rs
@@ -62,8 +62,13 @@ where
                     } => SliceOnePath::new(instances.clone(), NamedSliceOne::new(port.clone())),
                 };
                 let path = self.lib.scir.simplify_path(path);
-                Spice::node_voltage_path(&self.lib.scir, &NetlistLibConversion::new(), &path)
-                    .to_uppercase()
+                Spice::node_path_with_separator(
+                    &self.lib.scir,
+                    &NetlistLibConversion::new(),
+                    &path,
+                    "/",
+                )
+                .to_uppercase()
             })
             .collect();
         let nested_nodes = nested_nodes
@@ -77,8 +82,13 @@ where
                     } => SliceOnePath::new(instances.clone(), NamedSliceOne::new(port.clone())),
                 };
                 let path = self.lib.scir.simplify_path(path);
-                Spice::node_voltage_path(&self.lib.scir, &NetlistLibConversion::new(), &path)
-                    .to_uppercase()
+                Spice::node_path_with_separator(
+                    &self.lib.scir,
+                    &NetlistLibConversion::new(),
+                    &path,
+                    "/",
+                )
+                .to_uppercase()
             })
             .collect();
         let inner = <T as HasNestedDspfView>::Strings::unflatten(&self.inner, nodes, nested_nodes);

--- a/tools/spectre/src/dspf.rs
+++ b/tools/spectre/src/dspf.rs
@@ -87,7 +87,7 @@ where
                     &self.lib.scir,
                     &NetlistLibConversion::new(),
                     &path,
-                    "",
+                    "X",
                     "/",
                 )
                 .to_uppercase()

--- a/tools/spectre/src/dspf.rs
+++ b/tools/spectre/src/dspf.rs
@@ -17,13 +17,17 @@ pub struct DspfNodes<T> {
 
 /// A set of nodes in a nested DSPF netlist instantiation.
 pub struct DspfNestedNodes<T> {
+    /// The path to the DSPF instance.
     pub dspf_instance: InstancePath,
     /// The inner saved nodes.
     pub inner: T,
 }
 
+/// A node in an instance of a DSPF subcircuit.
 pub struct DspfNode {
+    /// The path to the DSPF instance.
     pub dspf_instance: InstancePath,
+    /// The path of the node within the DSPF netlist.
     pub path: String,
 }
 

--- a/tools/spectre/src/dspf.rs
+++ b/tools/spectre/src/dspf.rs
@@ -2,6 +2,7 @@
 
 use scir::{NamedSliceOne, NetlistLibConversion, SliceOnePath};
 use spice::Spice;
+use std::sync::Arc;
 use substrate::io::schematic::{NestedNode, Node};
 use substrate::schematic::conv::{ConvertedNodePath, RawLib};
 use substrate::schematic::{HasNestedView, InstancePath};
@@ -9,14 +10,16 @@ use substrate::schematic::{HasNestedView, InstancePath};
 /// A set of nodes in a DSPF netlist.
 pub struct DspfNodes<T> {
     /// The source spice file for this DSPF extracted view.
-    lib: RawLib<Spice>,
-    inner: T,
+    pub lib: RawLib<Spice>,
+    /// The inner saved nodes.
+    pub inner: Arc<T>,
 }
 
 /// A set of nodes in a nested DSPF netlist instantiation.
 pub struct DspfNestedNodes<T> {
     instances: InstancePath,
-    inner: T,
+    /// The inner saved nodes.
+    pub inner: T,
 }
 
 /// Indicates that a type has a nested DSPF view.

--- a/tools/spectre/src/dspf.rs
+++ b/tools/spectre/src/dspf.rs
@@ -61,6 +61,7 @@ where
                         instances, port, ..
                     } => SliceOnePath::new(instances.clone(), NamedSliceOne::new(port.clone())),
                 };
+                let path = self.lib.scir.simplify_path(path);
                 Spice::node_voltage_path(&self.lib.scir, &NetlistLibConversion::new(), &path)
                     .to_uppercase()
             })
@@ -75,6 +76,7 @@ where
                         instances, port, ..
                     } => SliceOnePath::new(instances.clone(), NamedSliceOne::new(port.clone())),
                 };
+                let path = self.lib.scir.simplify_path(path);
                 Spice::node_voltage_path(&self.lib.scir, &NetlistLibConversion::new(), &path)
                     .to_uppercase()
             })

--- a/tools/spectre/src/dspf.rs
+++ b/tools/spectre/src/dspf.rs
@@ -1,0 +1,101 @@
+//! DSPF netlists.
+
+use arcstr::ArcStr;
+use scir::{Library, NamedSliceOne, NetlistLibConversion, SliceOnePath};
+use spice::Spice;
+use substrate::io::schematic::{NestedNode, Node};
+use substrate::schematic::conv::{ConvertedNodePath, RawLib};
+use substrate::schematic::{HasNestedView, InstancePath};
+
+pub struct DspfNodes<T> {
+    instances: InstancePath,
+    /// The source spice file for this DSPF extracted view.
+    lib: RawLib<Spice>,
+    inner: T,
+}
+
+pub struct DspfNestedNodes<T> {
+    instances: InstancePath,
+    inner: T,
+}
+
+pub trait HasNestedDspfView: Sized {
+    type Strings: ReconstructDspfView<Self>;
+
+    fn flatten(&self) -> (Vec<Node>, Vec<NestedNode>);
+}
+
+pub trait ReconstructDspfView<T> {
+    fn unflatten(source: &T, nodes: Vec<String>, nested_nodes: Vec<String>) -> Self;
+}
+
+impl<T> HasNestedView for DspfNodes<T>
+where
+    T: HasNestedDspfView,
+    <T as HasNestedDspfView>::Strings: Send + Sync,
+{
+    type NestedView = DspfNestedNodes<<T as HasNestedDspfView>::Strings>;
+
+    fn nested_view(&self, parent: &InstancePath) -> Self::NestedView {
+        let (nodes, nested_nodes) = self.inner.flatten();
+        let nodes = nodes
+            .into_iter()
+            .map(|n| {
+                let path = self.lib.convert_node(&n).unwrap();
+                let path = match path {
+                    ConvertedNodePath::Cell(path) => path,
+                    ConvertedNodePath::Primitive {
+                        instances, port, ..
+                    } => SliceOnePath::new(instances.clone(), NamedSliceOne::new(port.clone())),
+                };
+                Spice::node_voltage_path(&self.lib.scir, &NetlistLibConversion::new(), &path)
+                    .to_uppercase()
+            })
+            .collect();
+        let nested_nodes = nested_nodes
+            .into_iter()
+            .map(|n| {
+                let path = self.lib.convert_node_path(&n.path()).unwrap();
+                let path = match path {
+                    ConvertedNodePath::Cell(path) => path,
+                    ConvertedNodePath::Primitive {
+                        instances, port, ..
+                    } => SliceOnePath::new(instances.clone(), NamedSliceOne::new(port.clone())),
+                };
+                Spice::node_voltage_path(&self.lib.scir, &NetlistLibConversion::new(), &path)
+                    .to_uppercase()
+            })
+            .collect();
+        let inner = <T as HasNestedDspfView>::Strings::unflatten(&self.inner, nodes, nested_nodes);
+        DspfNestedNodes {
+            instances: parent.clone(),
+            inner,
+        }
+    }
+}
+
+impl<T> HasNestedView for DspfNestedNodes<T>
+where
+    T: Send + Sync + Clone,
+{
+    type NestedView = DspfNestedNodes<T>;
+
+    fn nested_view(&self, parent: &InstancePath) -> Self::NestedView {
+        Self {
+            instances: self.instances.prepend(parent),
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl HasNestedDspfView for () {
+    type Strings = ();
+
+    fn flatten(&self) -> (Vec<Node>, Vec<NestedNode>) {
+        (Vec::new(), Vec::new())
+    }
+}
+
+impl ReconstructDspfView<()> for () {
+    fn unflatten(source: &(), nodes: Vec<String>, nested_nodes: Vec<String>) -> Self {}
+}

--- a/tools/spectre/src/dspf.rs
+++ b/tools/spectre/src/dspf.rs
@@ -1,31 +1,36 @@
 //! DSPF netlists.
 
-use arcstr::ArcStr;
-use scir::{Library, NamedSliceOne, NetlistLibConversion, SliceOnePath};
+use scir::{NamedSliceOne, NetlistLibConversion, SliceOnePath};
 use spice::Spice;
 use substrate::io::schematic::{NestedNode, Node};
 use substrate::schematic::conv::{ConvertedNodePath, RawLib};
 use substrate::schematic::{HasNestedView, InstancePath};
 
+/// A set of nodes in a DSPF netlist.
 pub struct DspfNodes<T> {
-    instances: InstancePath,
     /// The source spice file for this DSPF extracted view.
     lib: RawLib<Spice>,
     inner: T,
 }
 
+/// A set of nodes in a nested DSPF netlist instantiation.
 pub struct DspfNestedNodes<T> {
     instances: InstancePath,
     inner: T,
 }
 
+/// Indicates that a type has a nested DSPF view.
 pub trait HasNestedDspfView: Sized {
+    /// The node container type, where nodes are stored as strings.
     type Strings: ReconstructDspfView<Self>;
 
+    /// Flatten the container into a set of nodes and nested nodes.
     fn flatten(&self) -> (Vec<Node>, Vec<NestedNode>);
 }
 
+/// A type that can reconstruct a DSPF view.
 pub trait ReconstructDspfView<T> {
+    /// Unflatten the container from a set of nodes and nested nodes.
     fn unflatten(source: &T, nodes: Vec<String>, nested_nodes: Vec<String>) -> Self;
 }
 
@@ -97,5 +102,5 @@ impl HasNestedDspfView for () {
 }
 
 impl ReconstructDspfView<()> for () {
-    fn unflatten(source: &(), nodes: Vec<String>, nested_nodes: Vec<String>) -> Self {}
+    fn unflatten(_source: &(), _nodes: Vec<String>, _nested_nodes: Vec<String>) -> Self {}
 }

--- a/tools/spectre/src/dspf.rs
+++ b/tools/spectre/src/dspf.rs
@@ -62,10 +62,11 @@ where
                     } => SliceOnePath::new(instances.clone(), NamedSliceOne::new(port.clone())),
                 };
                 let path = self.lib.scir.simplify_path(path);
-                Spice::node_path_with_separator(
+                Spice::node_path_with_prefix_and_separator(
                     &self.lib.scir,
                     &NetlistLibConversion::new(),
                     &path,
+                    "X",
                     "/",
                 )
                 .to_uppercase()
@@ -82,10 +83,11 @@ where
                     } => SliceOnePath::new(instances.clone(), NamedSliceOne::new(port.clone())),
                 };
                 let path = self.lib.scir.simplify_path(path);
-                Spice::node_path_with_separator(
+                Spice::node_path_with_prefix_and_separator(
                     &self.lib.scir,
                     &NetlistLibConversion::new(),
                     &path,
+                    "",
                     "/",
                 )
                 .to_uppercase()

--- a/tools/spectre/src/dspf.rs
+++ b/tools/spectre/src/dspf.rs
@@ -17,9 +17,14 @@ pub struct DspfNodes<T> {
 
 /// A set of nodes in a nested DSPF netlist instantiation.
 pub struct DspfNestedNodes<T> {
-    instances: InstancePath,
+    pub dspf_instance: InstancePath,
     /// The inner saved nodes.
     pub inner: T,
+}
+
+pub struct DspfNode {
+    pub dspf_instance: InstancePath,
+    pub path: String,
 }
 
 /// Indicates that a type has a nested DSPF view.
@@ -76,7 +81,7 @@ where
             .collect();
         let inner = <T as HasNestedDspfView>::Strings::unflatten(&self.inner, nodes, nested_nodes);
         DspfNestedNodes {
-            instances: parent.clone(),
+            dspf_instance: parent.clone(),
             inner,
         }
     }
@@ -90,7 +95,7 @@ where
 
     fn nested_view(&self, parent: &InstancePath) -> Self::NestedView {
         Self {
-            instances: self.instances.prepend(parent),
+            dspf_instance: self.dspf_instance.prepend(parent),
             inner: self.inner.clone(),
         }
     }

--- a/tools/spectre/src/lib.rs
+++ b/tools/spectre/src/lib.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use crate::analysis::ac::{Ac, Sweep};
 use crate::analysis::montecarlo;
 use crate::analysis::montecarlo::MonteCarlo;
-use crate::dspf::DspfNode;
+
 use analysis::ac;
 use analysis::tran;
 use analysis::tran::Tran;

--- a/tools/spectre/src/lib.rs
+++ b/tools/spectre/src/lib.rs
@@ -53,6 +53,7 @@ use templates::{write_run_script, RunScriptContext};
 
 pub mod analysis;
 pub mod blocks;
+pub mod dspf;
 pub mod error;
 pub(crate) mod templates;
 


### PR DESCRIPTION
- **feat(spectre): support dspf nested views**
- **fix lints**
- **updates**
- **save dspf nodes**
- **simplify paths**
- **use correct path separator for dspf nodes**
- **add support for instance prefixes**
- **fix: X instead of empty string**
- **fix prefix**
- **fix lints**
