### PR TITLE
fix(def): remove whitespace after END DESIGN stmt

### DIFF
--- a/libs/lefdef/src/def.rs
+++ b/libs/lefdef/src/def.rs
@@ -105,7 +105,7 @@ impl WriteDef for Def {
             n.write(out)?;
         }
 
-        writeln!(out, "END DESIGN {}", self.design)?;
+        write!(out, "END DESIGN {}", self.design)?;
 
         Ok(())
     }


### PR DESCRIPTION
Newlines after `END DESIGN` may trigger warnings
in commercial tools.
