### PR TITLE
feat(transform): make transformations use integers instead of floats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1059,7 +1059,6 @@ dependencies = [
 name = "geometry"
 version = "0.5.0"
 dependencies = [
- "approx",
  "array_map",
  "geometry_macros",
  "impl-trait-for-tuples",

--- a/libs/atoll/src/abs.rs
+++ b/libs/atoll/src/abs.rs
@@ -657,7 +657,7 @@ impl<PDK: Pdk> Draw<PDK> for &DebugAbstract {
                             let text = Text::new(
                                 layer_id,
                                 format!("({x},{y})"),
-                                Transformation::translate(pt.x as f64, pt.y as f64),
+                                Transformation::translate(pt.x, pt.y),
                             );
                             recv.draw(text)?;
                         }

--- a/libs/atoll/src/grid.rs
+++ b/libs/atoll/src/grid.rs
@@ -1083,7 +1083,7 @@ impl<L: AtollLayer + Clone> RoutingState<L> {
     /// * We find two track coordinates on M(N+1): one by rounding up; the other by rounding down.
     /// * If the two coordinates are equal, we report a successor to that grid point.
     /// * Otherwise, we report a successor to the track with a closer physical coordinate, assuming
-    /// the farther coordinate is unobstructed.
+    ///   the farther coordinate is unobstructed.
     pub fn successors(
         &self,
         node: RoutingNode,

--- a/libs/atoll/src/route.rs
+++ b/libs/atoll/src/route.rs
@@ -158,7 +158,7 @@ where
             cost: Zero::zero(),
             index: i,
         });
-        parents.insert(node.clone(), (usize::max_value(), Zero::zero()));
+        parents.insert(node.clone(), (usize::MAX, Zero::zero()));
     }
     let mut target_reached = None;
     while let Some(SmallestHolder { cost, index }) = to_see.pop() {

--- a/libs/geometry/Cargo.toml
+++ b/libs/geometry/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 serde = { version = "1", features = ["derive"] }
 array_map = { version = "0.4", features = ["derive", "serde", "std"] }
 impl-trait-for-tuples = "0.2"
-approx = "0.5"
 num-rational = "0.4"
 
 geometry_macros = { version = "0.0.1", registry = "substrate", path = "../geometry_macros" }

--- a/libs/geometry/src/orientation.rs
+++ b/libs/geometry/src/orientation.rs
@@ -5,7 +5,7 @@ use std::hash::Hash;
 use approx::abs_diff_eq;
 use serde::{Deserialize, Serialize};
 
-use crate::transform::Transformation;
+use crate::transform::{Rotation, Transformation};
 
 /// A named orientation.
 #[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
@@ -39,7 +39,7 @@ pub enum NamedOrientation {
 /// An orientation of a geometric object.
 ///
 /// Captures reflection and rotation, but not position or scaling.
-#[derive(Debug, Default, Copy, Clone, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct Orientation {
     /// Reflect vertically.
     ///
@@ -48,7 +48,7 @@ pub struct Orientation {
     /// Counter-clockwise angle in degrees.
     ///
     /// Applied after reflecting vertically.
-    pub(crate) angle: f64,
+    pub(crate) angle: Rotation,
 }
 
 /// An orientation of a geometric object, represented as raw bytes.
@@ -58,7 +58,7 @@ pub struct OrientationBytes {
     ///
     /// Applied before rotation.
     pub(crate) reflect_vert: bool,
-    /// Counter-clockwise angle in degrees.
+    /// Counter-clockwise angle in degrees, represented as raw bytes from an [`f64`].
     ///
     /// Applied after reflecting vertically.
     pub(crate) angle: u64,
@@ -68,7 +68,7 @@ impl From<Orientation> for OrientationBytes {
     fn from(value: Orientation) -> Self {
         Self {
             reflect_vert: value.reflect_vert,
-            angle: value.angle.to_bits(),
+            angle: value.angle.degrees().to_bits(),
         }
     }
 }
@@ -96,15 +96,12 @@ impl NamedOrientation {
         Orientation::from(self)
     }
 
-    /// Attempts to convert the given orientation to a named orientation.
-    ///
-    /// The conversion is based on approximate equality.
-    /// If no named orientation is approximately equal to `orientation`,
-    /// returns [`None`].
-    pub fn from_orientation(orientation: Orientation) -> Option<Self> {
+    /// Converts the given orientation to a named orientation.
+    pub fn from_orientation(orientation: Orientation) -> Self {
         Self::all_rectangular()
             .into_iter()
-            .find(|o| orientation.approx_eq(&o.into_orientation()))
+            .find(|o| orientation == o.into_orientation())
+            .expect("orientation did not represent a valid Manhattan orientation")
     }
 }
 
@@ -112,14 +109,14 @@ impl From<NamedOrientation> for Orientation {
     fn from(value: NamedOrientation) -> Self {
         use NamedOrientation::*;
         let (reflect_vert, angle) = match value {
-            R0 => (false, 0.),
-            R90 | R270Cw => (false, 90.),
-            R180 | R180Cw => (false, 180.),
-            R270 | R90Cw => (false, 270.),
-            ReflectVert => (true, 0.),
-            FlipYx => (true, 90.),
-            ReflectHoriz => (true, 180.),
-            FlipMinusYx => (true, 270.),
+            R0 => (false, Rotation::R0),
+            R90 | R270Cw => (false, Rotation::R90),
+            R180 | R180Cw => (false, Rotation::R180),
+            R270 | R90Cw => (false, Rotation::R270),
+            ReflectVert => (true, Rotation::R0),
+            FlipYx => (true, Rotation::R90),
+            ReflectHoriz => (true, Rotation::R180),
+            FlipMinusYx => (true, Rotation::R270),
         };
         Self {
             reflect_vert,
@@ -131,7 +128,7 @@ impl From<NamedOrientation> for Orientation {
 impl Orientation {
     /// Creates a new orientation with the given reflection and angle settings.
     #[inline]
-    pub fn from_reflect_and_angle(reflect_vert: bool, angle: f64) -> Self {
+    pub fn from_reflect_and_angle(reflect_vert: bool, angle: Rotation) -> Self {
         Self {
             reflect_vert,
             angle,
@@ -164,8 +161,7 @@ impl Orientation {
             }
         }
 
-        // Keep the angle between 0 and 360 degrees.
-        self.wrap_angle()
+        self
     }
 
     /// Reflects the orientation vertically.
@@ -235,22 +231,8 @@ impl Orientation {
 
     /// Returns the angle associated with this orientation.
     #[inline]
-    pub fn angle(&self) -> f64 {
+    pub fn angle(&self) -> Rotation {
         self.angle
-    }
-
-    /// Wraps the given angle to the interval `[0, 360)` degrees.
-    #[inline]
-    fn wrap_angle(mut self) -> Self {
-        self.angle = crate::wrap_angle(self.angle);
-        self
-    }
-
-    /// Compares the two orientations for approximate equality.
-    pub fn approx_eq(&self, other: &Self) -> bool {
-        let a = self.wrap_angle();
-        let b = other.wrap_angle();
-        a.reflect_vert == b.reflect_vert && abs_diff_eq!(a.angle(), b.angle())
     }
 
     /// Returns the orientation represented by the given transformation.

--- a/libs/geometry/src/orientation.rs
+++ b/libs/geometry/src/orientation.rs
@@ -2,7 +2,6 @@
 
 use std::hash::Hash;
 
-use approx::abs_diff_eq;
 use serde::{Deserialize, Serialize};
 
 use crate::transform::{Rotation, Transformation};

--- a/libs/geometry/src/point.rs
+++ b/libs/geometry/src/point.rs
@@ -89,12 +89,7 @@ impl TranslateMut for Point {
 
 impl TransformMut for Point {
     fn transform_mut(&mut self, trans: Transformation) {
-        let xf = self.x as f64;
-        let yf = self.y as f64;
-        let x = trans.a[0][0] * xf + trans.a[0][1] * yf + trans.b[0];
-        let y = trans.a[1][0] * xf + trans.a[1][1] * yf + trans.b[1];
-        self.x = x.round() as i64;
-        self.y = y.round() as i64;
+        *self = trans.mat * *self + trans.b;
     }
 }
 
@@ -145,6 +140,16 @@ impl std::ops::SubAssign<Point> for Point {
     fn sub_assign(&mut self, rhs: Point) {
         self.x -= rhs.x;
         self.y -= rhs.y;
+    }
+}
+
+impl std::ops::Neg for Point {
+    type Output = Self;
+    fn neg(self) -> Self::Output {
+        Self {
+            x: -self.x,
+            y: -self.y,
+        }
     }
 }
 

--- a/libs/geometry/src/transform.rs
+++ b/libs/geometry/src/transform.rs
@@ -1,27 +1,250 @@
 //! Transformation types and traits.
 
-use approx::{AbsDiffEq, RelativeEq, UlpsEq};
+use std::f64::consts::PI;
+
 pub use geometry_macros::{TransformMut, TranslateMut};
 use impl_trait_for_tuples::impl_for_tuples;
 use serde::{Deserialize, Serialize};
 
 use super::orientation::Orientation;
 use crate::point::Point;
-use crate::wrap_angle;
 
-/// A transformation representing translation, rotation, and reflection of geometry.
+/// A transformation representing a Manhattan translation, rotation, and/or reflection of geometry.
 ///
 /// This object does not support scaling of geometry, and as such all transformation matrices
 /// should be unitary.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Transformation {
-    /// The transformation matrix represented in row-major order.
-    pub(crate) a: [[f64; 2]; 2],
+    /// The transformation matrix.
+    pub(crate) mat: TransformationMatrix,
     /// The x-y translation applied after the transformation.
-    pub(crate) b: [f64; 2],
+    pub(crate) b: Point,
 }
 
 impl Default for Transformation {
+    fn default() -> Self {
+        Self::identity()
+    }
+}
+
+/// A Manhattan rotation: 0, 90, 180, or 270 degrees counterclockwise.
+#[derive(Debug, Clone, Copy, Default, Eq, Ord, PartialOrd, PartialEq, Serialize, Deserialize)]
+pub enum Rotation {
+    /// 0 degrees; no rotation.
+    #[default]
+    R0,
+    /// 90 degrees counterclockwise.
+    R90,
+    /// 180 degrees counterclockwise.
+    R180,
+    /// 270 degrees counterclockwise.
+    R270,
+}
+
+impl std::ops::Add<Rotation> for Rotation {
+    type Output = Rotation;
+    fn add(self, rhs: Rotation) -> Self::Output {
+        use Rotation::*;
+        match (self, rhs) {
+            (R0, R0) => R0,
+            (R0, R90) => R90,
+            (R0, R180) => R180,
+            (R0, R270) => R270,
+            (R90, R0) => R90,
+            (R90, R90) => R180,
+            (R90, R180) => R270,
+            (R90, R270) => R0,
+            (R180, R0) => R180,
+            (R180, R90) => R270,
+            (R180, R180) => R0,
+            (R180, R270) => R90,
+            (R270, R0) => R270,
+            (R270, R90) => R0,
+            (R270, R180) => R90,
+            (R270, R270) => R180,
+        }
+    }
+}
+
+impl std::ops::AddAssign for Rotation {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+impl std::ops::Sub<Rotation> for Rotation {
+    type Output = Rotation;
+    fn sub(self, rhs: Rotation) -> Self::Output {
+        use Rotation::*;
+        match (self, rhs) {
+            (R0, R0) => R0,
+            (R0, R90) => R270,
+            (R0, R180) => R180,
+            (R0, R270) => R90,
+            (R90, R0) => R90,
+            (R90, R90) => R0,
+            (R90, R180) => R270,
+            (R90, R270) => R180,
+            (R180, R0) => R180,
+            (R180, R90) => R90,
+            (R180, R180) => R0,
+            (R180, R270) => R270,
+            (R270, R0) => R270,
+            (R270, R90) => R180,
+            (R270, R180) => R90,
+            (R270, R270) => R0,
+        }
+    }
+}
+
+impl std::ops::SubAssign for Rotation {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
+    }
+}
+
+impl Rotation {
+    /// The transformation matrix representing this rotation.
+    #[inline]
+    pub fn transformation_matrix(&self) -> TransformationMatrix {
+        TransformationMatrix::from(*self)
+    }
+
+    /// The angle of this rotation, in degrees.
+    pub fn degrees(&self) -> f64 {
+        match self {
+            Rotation::R0 => 0.,
+            Rotation::R90 => 90.,
+            Rotation::R180 => 180.,
+            Rotation::R270 => 270.,
+        }
+    }
+
+    /// The angle of this rotation, in radians.
+    pub fn radians(&self) -> f64 {
+        match self {
+            Rotation::R0 => 0.,
+            Rotation::R90 => PI / 2.,
+            Rotation::R180 => PI,
+            Rotation::R270 => PI * 1.5,
+        }
+    }
+}
+
+/// Indicates that an angle was not a valid Manhattan angle.
+///
+/// Manhattan angles (in degrees) are 0, 90, 180, 270,
+/// or any equivalent angle modulo 360 degrees.
+pub struct NonManhattanAngleError;
+
+impl TryFrom<f64> for Rotation {
+    type Error = NonManhattanAngleError;
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        let value = (((value % 360.) + 360.) % 360.).round() as i64;
+        match value {
+            0 => Ok(Rotation::R0),
+            90 => Ok(Rotation::R90),
+            180 => Ok(Rotation::R180),
+            270 => Ok(Rotation::R270),
+            _ => Err(NonManhattanAngleError),
+        }
+    }
+}
+
+/// A matrix representing a unitary transformation.
+///
+/// Can represent rotations, reflections, or combinations of rotations/reflections.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct TransformationMatrix([[i8; 2]; 2]);
+
+impl TransformationMatrix {
+    /// The identity transformation.
+    ///
+    /// Maps any point to itself.
+    #[inline]
+    pub fn identity() -> Self {
+        Self([[1, 0], [0, 1]])
+    }
+
+    /// A rotation matrix rotating by the given [`Rotation`].
+    pub fn rotate(&self, angle: Rotation) -> Self {
+        angle.transformation_matrix() * *self
+    }
+
+    /// A matrix representing a reflection across the x-axis.
+    pub fn reflect_vert(&self) -> Self {
+        Self([[1, 0], [0, -1]]) * *self
+    }
+
+    /// The inverse of the transformation matrix.
+    pub fn inverse(&self) -> Self {
+        Self(unitary_matinv(&self.0))
+    }
+}
+
+impl From<Rotation> for TransformationMatrix {
+    fn from(value: Rotation) -> Self {
+        Self(match value {
+            Rotation::R0 => [[1, 0], [0, 1]],
+            Rotation::R90 => [[0, -1], [1, 0]],
+            Rotation::R180 => [[-1, 0], [0, -1]],
+            Rotation::R270 => [[0, 1], [-1, 0]],
+        })
+    }
+}
+
+/// Multiples two 2x2 matrices, returning a new 2x2 matrix
+fn matmul_i8(a: &[[i8; 2]; 2], b: &[[i8; 2]; 2]) -> [[i8; 2]; 2] {
+    [
+        [
+            a[0][0] * b[0][0] + a[0][1] * b[1][0],
+            a[0][0] * b[0][1] + a[0][1] * b[1][1],
+        ],
+        [
+            a[1][0] * b[0][0] + a[1][1] * b[1][0],
+            a[1][0] * b[0][1] + a[1][1] * b[1][1],
+        ],
+    ]
+}
+
+/// Multiplies a 2x2 matrix by a 2-entry vector, returning a new 2-entry vector.
+fn matvec_i8_i64(a: &[[i8; 2]; 2], b: &[i64; 2]) -> [i64; 2] {
+    [
+        a[0][0] as i64 * b[0] + a[0][1] as i64 * b[1],
+        a[1][0] as i64 * b[0] + a[1][1] as i64 * b[1],
+    ]
+}
+
+impl std::ops::Mul<TransformationMatrix> for TransformationMatrix {
+    type Output = Self;
+    fn mul(self, rhs: TransformationMatrix) -> Self::Output {
+        Self(matmul_i8(&self.0, &rhs.0))
+    }
+}
+
+impl std::ops::Mul<Point> for TransformationMatrix {
+    type Output = Point;
+    fn mul(self, rhs: Point) -> Self::Output {
+        let out = matvec_i8_i64(&self.0, &[rhs.x, rhs.y]);
+        Point::new(out[0], out[1])
+    }
+}
+
+impl std::ops::Deref for TransformationMatrix {
+    type Target = [[i8; 2]; 2];
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for TransformationMatrix {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Default for TransformationMatrix {
+    #[inline]
     fn default() -> Self {
         Self::identity()
     }
@@ -31,31 +254,30 @@ impl Transformation {
     /// Returns the identity transform, leaving any transformed object unmodified.
     pub fn identity() -> Self {
         Self {
-            a: [[1., 0.], [0., 1.]],
-            b: [0., 0.],
+            mat: TransformationMatrix::identity(),
+            b: Point::zero(),
         }
     }
     /// Returns a translation by `(x,y)`.
-    pub fn translate(x: f64, y: f64) -> Self {
+    pub fn translate(x: i64, y: i64) -> Self {
         Self {
-            a: [[1., 0.], [0., 1.]],
-            b: [x, y],
+            mat: TransformationMatrix::identity(),
+            b: Point::new(x, y),
         }
     }
     /// Returns a rotatation by `angle` degrees.
-    pub fn rotate(angle: f64) -> Self {
-        let sin = angle.to_radians().sin();
-        let cos = angle.to_radians().cos();
+    pub fn rotate(angle: Rotation) -> Self {
+        let mat = TransformationMatrix::from(angle);
         Self {
-            a: [[cos, -sin], [sin, cos]],
-            b: [0., 0.],
+            mat,
+            b: Point::zero(),
         }
     }
     /// Returns a reflection about the x-axis.
     pub fn reflect_vert() -> Self {
         Self {
-            a: [[1., 0.], [0., -1.]],
-            b: [0., 0.],
+            mat: TransformationMatrix([[1, 0], [0, -1]]),
+            b: Point::zero(),
         }
     }
 
@@ -86,7 +308,7 @@ impl Transformation {
 
     /// Creates a transform from an offset, angle, and a bool indicating
     /// whether or not to reflect vertically.
-    pub fn from_opts(offset: Point, reflect_vert: bool, angle: f64) -> Self {
+    pub fn from_opts(offset: Point, reflect_vert: bool, angle: Rotation) -> Self {
         Self::builder()
             .point(offset)
             .reflect_vert(reflect_vert)
@@ -109,32 +331,29 @@ impl Transformation {
     pub fn cascade(parent: Transformation, child: Transformation) -> Transformation {
         // The result-transform's origin is the parent's origin,
         // plus the parent-transformed child's origin
-        let mut b = matvec(&parent.a, &child.b);
-        b[0] += parent.b[0];
-        b[1] += parent.b[1];
+        let mut b = parent.mat * child.b;
+        b += parent.b;
         // And the cascade-matrix is the product of the parent's and child's
-        let a = matmul(&parent.a, &child.a);
-        Self { a, b }
+        let mat = parent.mat * child.mat;
+        Self { mat, b }
     }
 
     /// The point representing the translation of this transformation.
     pub fn offset_point(&self) -> Point {
-        Point {
-            x: self.b[0].round() as i64,
-            y: self.b[1].round() as i64,
-        }
+        self.b
     }
 
     /// Returns an [`Orientation`] corresponding to this transformation.
     pub fn orientation(&self) -> Orientation {
-        let reflect_vert = self.a[0][0].signum() != self.a[1][1].signum();
-        let sin = self.a[1][0];
-        let cos = self.a[0][0];
-        let angle = cos.acos().to_degrees();
-        let angle = if sin > 0f64 {
-            angle
-        } else {
-            wrap_angle(-angle)
+        let reflect_vert = self.mat[0][0].signum() != self.mat[1][1].signum();
+        let cos = self.mat[0][0];
+        let sin = self.mat[1][0];
+        let angle = match (cos, sin) {
+            (1, 0) => Rotation::R0,
+            (0, 1) => Rotation::R90,
+            (-1, 0) => Rotation::R180,
+            (0, -1) => Rotation::R270,
+            _ => panic!("transformation did not represent a valid Manhattan transformation"),
         };
         Orientation {
             reflect_vert,
@@ -151,20 +370,17 @@ impl Transformation {
     /// use approx::assert_relative_eq;
     ///
     /// let trans = Transformation::cascade(
-    ///     Transformation::rotate(90.),
-    ///     Transformation::translate(5., 10.),
+    ///     Transformation::rotate(90),
+    ///     Transformation::translate(5., 10),
     /// );
     /// let inv = trans.inv();
     ///
     /// assert_relative_eq!(Transformation::cascade(inv, trans), Transformation::identity());
     /// ```
     pub fn inv(&self) -> Transformation {
-        let inv = unitary_matinv(&self.a);
-        let invb = matvec(&inv, &self.b);
-        Self {
-            a: inv,
-            b: [-invb[0], -invb[1]],
-        }
+        let inv = self.mat.inverse();
+        let invb = inv * self.b;
+        Self { mat: inv, b: -invb }
     }
 }
 
@@ -177,63 +393,27 @@ where
     }
 }
 
-impl AbsDiffEq for Transformation {
-    type Epsilon = f64;
-
-    fn default_epsilon() -> Self::Epsilon {
-        f64::default_epsilon()
-    }
-
-    fn abs_diff_eq(&self, other: &Self, epsilon: f64) -> bool {
-        self.a[0].abs_diff_eq(&other.a[0], epsilon)
-            && self.a[1].abs_diff_eq(&other.a[1], epsilon)
-            && self.b.abs_diff_eq(&other.b, epsilon)
-    }
-}
-
-impl RelativeEq for Transformation {
-    fn default_max_relative() -> f64 {
-        f64::default_max_relative()
-    }
-
-    fn relative_eq(&self, other: &Self, epsilon: f64, max_relative: f64) -> bool {
-        self.a[0].relative_eq(&other.a[0], epsilon, max_relative)
-            && self.a[1].relative_eq(&other.a[1], epsilon, max_relative)
-            && self.b.relative_eq(&other.b, epsilon, max_relative)
-    }
-}
-
-impl UlpsEq for Transformation {
-    fn default_max_ulps() -> u32 {
-        f64::default_max_ulps()
-    }
-
-    fn ulps_eq(&self, other: &Self, epsilon: f64, max_ulps: u32) -> bool {
-        self.a[0].ulps_eq(&other.a[0], epsilon, max_ulps)
-            && self.a[1].ulps_eq(&other.a[1], epsilon, max_ulps)
-            && self.b.ulps_eq(&other.b, epsilon, max_ulps)
-    }
-}
-
 /// A builder for creating transformations from translations and [`Orientation`]s.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct TransformationBuilder {
-    x: f64,
-    y: f64,
+    x: i64,
+    y: i64,
     reflect_vert: bool,
-    angle: f64,
+    angle: Rotation,
 }
 
 impl TransformationBuilder {
     /// Specifies the x-y translation encoded by the transformation.
     pub fn point(&mut self, point: impl Into<Point>) -> &mut Self {
         let point = point.into();
-        self.x = point.x as f64;
-        self.y = point.y as f64;
+        self.x = point.x;
+        self.y = point.y;
         self
     }
 
     /// Specifies the [`Orientation`] applied by this transformation.
+    ///
+    /// This overrides any angle and reflection settings previously applied.
     pub fn orientation(&mut self, o: impl Into<Orientation>) -> &mut Self {
         let o = o.into();
         self.reflect_vert = o.reflect_vert;
@@ -242,7 +422,7 @@ impl TransformationBuilder {
     }
 
     /// Specifies the angle of rotation encoded by this transformation.
-    pub fn angle(&mut self, angle: f64) -> &mut Self {
+    pub fn angle(&mut self, angle: Rotation) -> &mut Self {
         self.angle = angle;
         self
     }
@@ -255,43 +435,23 @@ impl TransformationBuilder {
 
     /// Builds a [`Transformation`] from the specified parameters.
     pub fn build(&mut self) -> Transformation {
-        let b = [self.x, self.y];
-        let sin = self.angle.to_radians().sin();
-        let cos = self.angle.to_radians().cos();
-        let sin_refl = if self.reflect_vert { sin } else { -sin };
-        let cos_refl = if self.reflect_vert { -cos } else { cos };
-        let a = [[cos, sin_refl], [sin, cos_refl]];
-        Transformation { a, b }
+        let mut mat = self.angle.transformation_matrix();
+        if self.reflect_vert {
+            mat[0][1] = -mat[0][1];
+            mat[1][1] = -mat[1][1];
+        }
+        Transformation {
+            mat,
+            b: Point::new(self.x, self.y),
+        }
     }
-}
-
-/// Multiples two 2x2 matrices, returning a new 2x2 matrix
-fn matmul(a: &[[f64; 2]; 2], b: &[[f64; 2]; 2]) -> [[f64; 2]; 2] {
-    [
-        [
-            a[0][0] * b[0][0] + a[0][1] * b[1][0],
-            a[0][0] * b[0][1] + a[0][1] * b[1][1],
-        ],
-        [
-            a[1][0] * b[0][0] + a[1][1] * b[1][0],
-            a[1][0] * b[0][1] + a[1][1] * b[1][1],
-        ],
-    ]
-}
-
-/// Multiplies a 2x2 matrix by a 2-entry vector, returning a new 2-entry vector.
-fn matvec(a: &[[f64; 2]; 2], b: &[f64; 2]) -> [f64; 2] {
-    [
-        a[0][0] * b[0] + a[0][1] * b[1],
-        a[1][0] * b[0] + a[1][1] * b[1],
-    ]
 }
 
 /// Finds the inverse of the matrix.
 ///
 /// The determinant factor is unecessary since all transformation matrices have determinant 1 (no
 /// scaling).
-fn unitary_matinv(a: &[[f64; 2]; 2]) -> [[f64; 2]; 2] {
+fn unitary_matinv(a: &[[i8; 2]; 2]) -> [[i8; 2]; 2] {
     [[a[1][1], -a[0][1]], [-a[1][0], a[0][0]]]
 }
 
@@ -403,35 +563,32 @@ impl<T: HasTransformedView> HasTransformedView for Vec<T> {
 
 #[cfg(test)]
 mod tests {
-
-    use approx::assert_relative_eq;
-
     use super::*;
     use crate::{orientation::NamedOrientation, rect::Rect};
 
     #[test]
     fn matvec_works() {
-        let a = [[1., 2.], [3., 4.]];
-        let b = [5., 6.];
-        assert_eq!(matvec(&a, &b), [17., 39.]);
+        let a = [[1, 2], [3, 4]];
+        let b = [5, 6];
+        assert_eq!(matvec_i8_i64(&a, &b), [17, 39]);
     }
 
     #[test]
     fn matmul_works() {
-        let a = [[1., 2.], [3., 4.]];
-        let b = [[5., 6.], [7., 8.]];
-        assert_eq!(matmul(&a, &b), [[19., 22.], [43., 50.]]);
+        let a = [[1, 2], [3, 4]];
+        let b = [[5, 6], [7, 8]];
+        assert_eq!(matmul_i8(&a, &b), [[19, 22], [43, 50]]);
     }
 
     #[test]
     fn unitary_matinv_works() {
-        let a = [[1., 1.], [3., 4.]];
+        let a = [[1, 1], [3, 4]];
         let inv = unitary_matinv(&a);
-        let a_mul_inv = matmul(&a, &inv);
-        assert_relative_eq!(a_mul_inv[0][0], 1.);
-        assert_relative_eq!(a_mul_inv[0][1], 0.);
-        assert_relative_eq!(a_mul_inv[1][0], 0.);
-        assert_relative_eq!(a_mul_inv[1][1], 1.);
+        let a_mul_inv = matmul_i8(&a, &inv);
+        assert_eq!(a_mul_inv[0][0], 1);
+        assert_eq!(a_mul_inv[0][1], 0);
+        assert_eq!(a_mul_inv[1][0], 0);
+        assert_eq!(a_mul_inv[1][1], 1);
     }
 
     #[test]

--- a/libs/geometry/src/transform.rs
+++ b/libs/geometry/src/transform.rs
@@ -326,6 +326,7 @@ impl Transformation {
     /// * (a) Reflect vertically, then
     /// * (b) Translate by (1,1)
     /// * (c) Place a point at (local coordinate) (1,1)
+    ///
     /// Lands said point at (2,-2) in top-level space,
     /// whereas reversing the order of (a) and (b) lands it at (2,0).
     pub fn cascade(parent: Transformation, child: Transformation) -> Transformation {


### PR DESCRIPTION
Transformations now only encode Manhattan transformations
and internally store a transformation matrix with integer (i8)
entries, as opposed to f64 entries.
