### PR TITLE
feat(transform): default to Manhattan transformations

### DIFF
--- a/codegen/src/block/layout.rs
+++ b/codegen/src/block/layout.rs
@@ -4,7 +4,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote, ToTokens};
 
 use crate::substrate_ident;
-use type_dispatch::derive::{add_trait_bounds, struct_body};
+use type_dispatch::derive::add_trait_bounds;
 
 #[derive(Debug, FromDeriveInput)]
 #[darling(supports(struct_any, enum_any), forward_attrs(allow, doc, cfg))]
@@ -12,8 +12,6 @@ pub struct DataInputReceiver {
     ident: syn::Ident,
     generics: syn::Generics,
     data: ast::Data<DataVariant, DataField>,
-    vis: syn::Visibility,
-    attrs: Vec<syn::Attribute>,
 }
 
 #[derive(Debug, FromVariant)]
@@ -29,9 +27,7 @@ pub struct DataVariant {
 #[darling(attributes(substrate), forward_attrs(allow, doc, cfg))]
 pub struct DataField {
     ident: Option<syn::Ident>,
-    vis: syn::Visibility,
     ty: syn::Type,
-    attrs: Vec<syn::Attribute>,
 }
 
 fn tuple_ident(idx: usize) -> syn::Ident {
@@ -143,8 +139,6 @@ impl ToTokens for DataInputReceiver {
             ref ident,
             ref generics,
             ref data,
-            ref vis,
-            ref attrs,
         } = *self;
         let mut xform_generics = generics.clone();
         add_trait_bounds(

--- a/codegen/src/block/layout.rs
+++ b/codegen/src/block/layout.rs
@@ -34,31 +34,11 @@ pub struct DataField {
     attrs: Vec<syn::Attribute>,
 }
 
-fn transform_variant_decl(variant: &DataVariant) -> TokenStream {
-    let DataVariant {
-        ref ident,
-        ref fields,
-        ..
-    } = variant;
-    let decls = fields
-        .iter()
-        .enumerate()
-        .map(|(i, f)| transform_field_decl(i, f));
-    match fields.style {
-        Style::Unit => quote!(#ident,),
-        Style::Tuple => quote!(#ident( #(#decls)* ),),
-        Style::Struct => quote!(#ident { #(#decls)* },),
-    }
-}
-
 fn tuple_ident(idx: usize) -> syn::Ident {
     format_ident!("__substrate_derive_field{idx}")
 }
 
-fn transform_variant_match_arm(
-    transformed_ident: syn::Ident,
-    variant: &DataVariant,
-) -> TokenStream {
+fn transform_variant_match_arm(variant: &DataVariant) -> TokenStream {
     let DataVariant {
         ref ident,
         ref fields,
@@ -74,38 +54,38 @@ fn transform_variant_match_arm(
         .enumerate()
         .map(|(i, f)| transform_field_assign(false, i, f));
     match fields.style {
-        Style::Unit => quote!(Self::#ident => #transformed_ident::#ident,),
+        Style::Unit => quote!(Self::#ident => Self::#ident,),
         Style::Tuple => {
-            quote!(Self::#ident( #(#destructure),* ) => #transformed_ident::#ident( #(#assign)* ),)
+            quote!(Self::#ident( #(#destructure),* ) => Self::#ident( #(#assign)* ),)
         }
         Style::Struct => {
-            quote!(Self::#ident { #(#destructure),* } => #transformed_ident::#ident { #(#assign)* },)
+            quote!(Self::#ident { #(#destructure),* } => Self::#ident { #(#assign)* },)
         }
     }
 }
 
-fn transform_field_decl(_idx: usize, field: &DataField) -> TokenStream {
-    let DataField {
+fn translate_variant_match_arm(variant: &DataVariant) -> TokenStream {
+    let DataVariant {
         ref ident,
-        ref vis,
-        ref ty,
-        ref attrs,
-    } = field;
-    let substrate = substrate_ident();
-    let field_ty = quote!(#substrate::geometry::transform::Transformed<#ty>);
-
-    match ident {
-        Some(ident) => {
-            quote! {
-                #(#attrs)*
-                #vis #ident: #field_ty,
-            }
+        ref fields,
+        ..
+    } = variant;
+    let destructure = fields
+        .iter()
+        .enumerate()
+        .map(|(i, f)| f.ident.clone().unwrap_or_else(|| tuple_ident(i)))
+        .map(|i| quote!(ref #i));
+    let assign = fields
+        .iter()
+        .enumerate()
+        .map(|(i, f)| translate_field_assign(false, i, f));
+    match fields.style {
+        Style::Unit => quote!(Self::#ident => Self::#ident,),
+        Style::Tuple => {
+            quote!(Self::#ident( #(#destructure),* ) => Self::#ident( #(#assign)* ),)
         }
-        None => {
-            quote! {
-                #(#attrs)*
-                #vis #field_ty,
-            }
+        Style::Struct => {
+            quote!(Self::#ident { #(#destructure),* } => Self::#ident { #(#assign)* },)
         }
     }
 }
@@ -125,7 +105,30 @@ fn transform_field_assign(use_self: bool, idx: usize, field: &DataField) -> Toke
         (false, None) => quote!(&#tuple_ident),
     };
 
-    let value = quote!(<#ty as #substrate::geometry::transform::HasTransformedView>::transformed_view(#val, __substrate_derive_transformation));
+    let value = quote!(<#ty as #substrate::geometry::transform::TransformRef>::transform_ref(#val, __substrate_derive_transformation));
+
+    match ident {
+        Some(ident) => quote! { #ident: #value, },
+        None => quote! { #value, },
+    }
+}
+
+fn translate_field_assign(use_self: bool, idx: usize, field: &DataField) -> TokenStream {
+    let DataField {
+        ref ident, ref ty, ..
+    } = field;
+    let substrate = substrate_ident();
+    let tuple_ident = tuple_ident(idx);
+    let idx = syn::Index::from(idx);
+
+    let val = match (use_self, ident) {
+        (true, Some(ident)) => quote!(&self.#ident),
+        (true, None) => quote!(&self.#idx),
+        (false, Some(ident)) => quote!(&#ident),
+        (false, None) => quote!(&#tuple_ident),
+    };
+
+    let value = quote!(<#ty as #substrate::geometry::transform::TranslateRef>::translate_ref(#val, __substrate_derive_point));
 
     match ident {
         Some(ident) => quote! { #ident: #value, },
@@ -143,68 +146,81 @@ impl ToTokens for DataInputReceiver {
             ref vis,
             ref attrs,
         } = *self;
-        let mut generics = generics.clone();
+        let mut xform_generics = generics.clone();
         add_trait_bounds(
-            &mut generics,
-            quote!(#substrate::geometry::transform::HasTransformedView),
+            &mut xform_generics,
+            quote!(#substrate::geometry::transform::TransformRef),
         );
-
-        let (imp, ty, wher) = generics.split_for_impl();
-        let transformed_ident = format_ident!("{}TransformedView", ident);
+        let (ximp, xty, xwher) = xform_generics.split_for_impl();
+        let mut trans_generics = generics.clone();
+        add_trait_bounds(
+            &mut trans_generics,
+            quote!(#substrate::geometry::transform::TranslateRef),
+        );
+        let (timp, tty, twher) = trans_generics.split_for_impl();
 
         let expanded = match data {
             ast::Data::Struct(ref fields) => {
-                let decls = fields
-                    .iter()
-                    .enumerate()
-                    .map(|(i, f)| transform_field_decl(i, f));
-                let assignments = fields
+                let xform_assignments = fields
                     .iter()
                     .enumerate()
                     .map(|(i, f)| transform_field_assign(true, i, f));
-                let retval = match fields.style {
-                    Style::Unit => quote!(#transformed_ident),
-                    Style::Tuple => quote!(#transformed_ident( #(#assignments)* )),
-                    Style::Struct => quote!(#transformed_ident { #(#assignments)* }),
+                let trans_assignments = fields
+                    .iter()
+                    .enumerate()
+                    .map(|(i, f)| translate_field_assign(true, i, f));
+                let transformed = match fields.style {
+                    Style::Unit => quote!(#ident),
+                    Style::Tuple => quote!(#ident( #(#xform_assignments)* )),
+                    Style::Struct => quote!(#ident { #(#xform_assignments)* }),
+                };
+                let translated = match fields.style {
+                    Style::Unit => quote!(#ident),
+                    Style::Tuple => quote!(#ident( #(#trans_assignments)* )),
+                    Style::Struct => quote!(#ident { #(#trans_assignments)* }),
                 };
 
-                let body = struct_body(fields.style, true, quote! {#( #decls )*});
-
                 quote! {
-                    #(#attrs)*
-                    #vis struct #transformed_ident #generics #body
+                    impl #timp #substrate::geometry::transform::TranslateRef for #ident #tty #twher {
+                        fn translate_ref(
+                            &self,
+                            __substrate_derive_point: #substrate::geometry::point::Point,
+                        ) -> Self {
+                            #translated
+                        }
+                    }
 
-                    impl #imp #substrate::geometry::transform::HasTransformedView for #ident #ty #wher {
-                        type TransformedView = #transformed_ident #ty;
-
-                        fn transformed_view(
+                    impl #ximp #substrate::geometry::transform::TransformRef for #ident #xty #xwher {
+                        fn transform_ref(
                             &self,
                             __substrate_derive_transformation: #substrate::geometry::transform::Transformation,
-                        ) -> Self::TransformedView {
-                            #retval
+                        ) -> Self {
+                            #transformed
                         }
                     }
                 }
             }
             ast::Data::Enum(ref variants) => {
-                let decls = variants.iter().map(transform_variant_decl);
-                let arms = variants
-                    .iter()
-                    .map(|v| transform_variant_match_arm(transformed_ident.clone(), v));
+                let xform_arms = variants.iter().map(transform_variant_match_arm);
+                let trans_arms = variants.iter().map(translate_variant_match_arm);
                 quote! {
-                    #(#attrs)*
-                    #vis enum #transformed_ident #generics {
-                        #( #decls )*
+                    impl #timp #substrate::geometry::transform::TranslateRef for #ident #tty #twher {
+                        fn translate_ref(
+                            &self,
+                            __substrate_derive_point: #substrate::geometry::point::Point,
+                        ) -> Self {
+                            match self {
+                                #(#trans_arms)*
+                            }
+                        }
                     }
-                    impl #imp #substrate::geometry::transform::HasTransformedView for #ident #ty #wher {
-                        type TransformedView = #transformed_ident #ty;
-
-                        fn transformed_view(
+                    impl #ximp #substrate::geometry::transform::TransformRef for #ident #xty #xwher {
+                        fn transform_ref(
                             &self,
                             __substrate_derive_transformation: #substrate::geometry::transform::Transformation,
-                        ) -> Self::TransformedView {
+                        ) -> Self {
                             match self {
-                                #(#arms)*
+                                #(#xform_arms)*
                             }
                         }
                     }

--- a/libs/geometry/src/point.rs
+++ b/libs/geometry/src/point.rs
@@ -7,7 +7,9 @@ use crate::dims::Dims;
 use crate::dir::Dir;
 use crate::prelude::Transform;
 use crate::snap::snap_to_grid;
-use crate::transform::{HasTransformedView, TransformMut, Transformation, TranslateMut};
+use crate::transform::{
+    TransformMut, TransformRef, Transformation, Translate, TranslateMut, TranslateRef,
+};
 
 /// A point in two-dimensional space.
 #[derive(
@@ -80,6 +82,12 @@ impl Point {
     }
 }
 
+impl TranslateRef for Point {
+    fn translate_ref(&self, p: Point) -> Self {
+        self.translate(p)
+    }
+}
+
 impl TranslateMut for Point {
     fn translate_mut(&mut self, p: Point) {
         self.x += p.x;
@@ -87,17 +95,15 @@ impl TranslateMut for Point {
     }
 }
 
-impl TransformMut for Point {
-    fn transform_mut(&mut self, trans: Transformation) {
-        *self = trans.mat * *self + trans.b;
+impl TransformRef for Point {
+    fn transform_ref(&self, trans: Transformation) -> Self {
+        self.transform(trans)
     }
 }
 
-impl HasTransformedView for Point {
-    type TransformedView = Point;
-
-    fn transformed_view(&self, trans: Transformation) -> Self::TransformedView {
-        self.transform(trans)
+impl TransformMut for Point {
+    fn transform_mut(&mut self, trans: Transformation) {
+        *self = trans.mat * *self + trans.b;
     }
 }
 

--- a/libs/geometry/src/polygon.rs
+++ b/libs/geometry/src/polygon.rs
@@ -6,7 +6,7 @@ use crate::bbox::Bbox;
 use crate::contains::{Containment, Contains};
 use crate::point::Point;
 use crate::rect::Rect;
-use crate::transform::{TransformMut, Transformation, TranslateMut};
+use crate::transform::{TransformMut, TransformRef, Transformation, TranslateMut, TranslateRef};
 use num_rational::Ratio;
 
 /// A polygon, with vertex coordinates given
@@ -151,9 +151,25 @@ fn triangle_area(v1: Point, v2: Point, v3: Point) -> Ratio<i64> {
     )
 }
 
+impl TranslateRef for Polygon {
+    fn translate_ref(&self, p: Point) -> Self {
+        Self {
+            points: self.points.translate_ref(p),
+        }
+    }
+}
+
 impl TranslateMut for Polygon {
     fn translate_mut(&mut self, p: Point) {
         self.points.translate_mut(p);
+    }
+}
+
+impl TransformRef for Polygon {
+    fn transform_ref(&self, trans: Transformation) -> Self {
+        Self {
+            points: self.points.transform_ref(trans),
+        }
     }
 }
 

--- a/libs/geometry/src/rect.rs
+++ b/libs/geometry/src/rect.rs
@@ -10,10 +10,11 @@ use crate::dir::Dir;
 use crate::edge::Edge;
 use crate::intersect::Intersect;
 use crate::point::Point;
-use crate::prelude::Transform;
 use crate::side::{Side, Sides};
 use crate::span::Span;
-use crate::transform::{HasTransformedView, TransformMut, Transformation, TranslateMut};
+use crate::transform::{
+    Transform, TransformMut, TransformRef, Transformation, Translate, TranslateMut, TranslateRef,
+};
 use crate::union::BoundingUnion;
 
 /// An axis-aligned rectangle, specified by lower-left and upper-right corners.
@@ -1350,10 +1351,24 @@ impl Intersect<Rect> for Rect {
     }
 }
 
+impl TranslateRef for Rect {
+    #[inline]
+    fn translate_ref(&self, p: Point) -> Self {
+        self.translate(p)
+    }
+}
+
 impl TranslateMut for Rect {
     fn translate_mut(&mut self, p: Point) {
         self.p0.translate_mut(p);
         self.p1.translate_mut(p);
+    }
+}
+
+impl TransformRef for Rect {
+    #[inline]
+    fn transform_ref(&self, trans: Transformation) -> Self {
+        self.transform(trans)
     }
 }
 
@@ -1365,14 +1380,6 @@ impl TransformMut for Rect {
 
         self.p0 = Point::new(std::cmp::min(p0.x, p1.x), std::cmp::min(p0.y, p1.y));
         self.p1 = Point::new(std::cmp::max(p0.x, p1.x), std::cmp::max(p0.y, p1.y));
-    }
-}
-
-impl HasTransformedView for Rect {
-    type TransformedView = Rect;
-
-    fn transformed_view(&self, trans: Transformation) -> Self::TransformedView {
-        self.transform(trans)
     }
 }
 

--- a/libs/geometry/src/shape.rs
+++ b/libs/geometry/src/shape.rs
@@ -3,10 +3,10 @@
 use crate::{
     bbox::Bbox,
     contains::{Containment, Contains},
+    point::Point,
     polygon::Polygon,
-    prelude::Transform,
     rect::Rect,
-    transform::{HasTransformedView, TransformMut, TranslateMut},
+    transform::{TransformMut, TransformRef, Transformation, TranslateMut, TranslateRef},
     union::BoundingUnion,
 };
 
@@ -39,8 +39,19 @@ impl Shape {
     }
 }
 
+impl TranslateRef for Shape {
+    #[inline]
+    fn translate_ref(&self, p: Point) -> Self {
+        match self {
+            Shape::Rect(rect) => Shape::Rect(rect.translate_ref(p)),
+            Shape::Polygon(polygon) => Shape::Polygon(polygon.translate_ref(p)),
+        }
+    }
+}
+
 impl TranslateMut for Shape {
-    fn translate_mut(&mut self, p: crate::point::Point) {
+    #[inline]
+    fn translate_mut(&mut self, p: Point) {
         match self {
             Shape::Rect(rect) => rect.translate_mut(p),
             Shape::Polygon(polygon) => polygon.translate_mut(p),
@@ -48,20 +59,23 @@ impl TranslateMut for Shape {
     }
 }
 
+impl TransformRef for Shape {
+    #[inline]
+    fn transform_ref(&self, trans: Transformation) -> Self {
+        match self {
+            Shape::Rect(rect) => Shape::Rect(rect.transform_ref(trans)),
+            Shape::Polygon(polygon) => Shape::Polygon(polygon.transform_ref(trans)),
+        }
+    }
+}
+
 impl TransformMut for Shape {
+    #[inline]
     fn transform_mut(&mut self, trans: crate::prelude::Transformation) {
         match self {
             Shape::Rect(rect) => rect.transform_mut(trans),
             Shape::Polygon(polygon) => polygon.transform_mut(trans),
         }
-    }
-}
-
-impl HasTransformedView for Shape {
-    type TransformedView = Shape;
-
-    fn transformed_view(&self, trans: crate::prelude::Transformation) -> Self::TransformedView {
-        self.clone().transform(trans)
     }
 }
 

--- a/libs/geometry/src/transform.rs
+++ b/libs/geometry/src/transform.rs
@@ -480,7 +480,7 @@ impl<T: TransformRef> TransformRef for Option<T> {
 
 /// A trait for specifying how an object is changed by a [`Transformation`].
 #[impl_for_tuples(32)]
-pub trait TransformMut {
+pub trait TransformMut: TranslateMut {
     /// Applies matrix-vector [`Transformation`] `trans`.
     fn transform_mut(&mut self, trans: Transformation);
 }
@@ -504,7 +504,7 @@ impl<T: TransformMut> TransformMut for Option<T> {
 /// A trait for specifying how an object is changed by a [`Transformation`].
 ///
 /// Takes in an owned copy of the shape and returns the transformed version.
-pub trait Transform: TransformMut + Sized {
+pub trait Transform: Translate + TransformMut + Sized {
     /// Applies matrix-vector [`Transformation`] `trans`.
     ///
     /// Creates a new shape at a location equal to the transformation of the original.

--- a/libs/geometry/src/transform.rs
+++ b/libs/geometry/src/transform.rs
@@ -265,6 +265,14 @@ impl Transformation {
             b: Point::new(x, y),
         }
     }
+    /// Translates the current transformation by `(x, y)`, returning a new [`Transformation`].
+    pub fn translate_ref(&self, x: i64, y: i64) -> Self {
+        Self {
+            mat: self.mat,
+            b: Point::new(x, y) + self.b,
+        }
+    }
+
     /// Returns a rotatation by `angle` degrees.
     pub fn rotate(angle: Rotation) -> Self {
         let mat = TransformationMatrix::from(angle);

--- a/libs/geometry/src/transform.rs
+++ b/libs/geometry/src/transform.rs
@@ -346,7 +346,11 @@ impl Transformation {
 
     /// Returns an [`Orientation`] corresponding to this transformation.
     pub fn orientation(&self) -> Orientation {
-        let reflect_vert = self.mat[0][0].signum() != self.mat[1][1].signum();
+        let reflect_vert = if self.mat[0][0] == 0 {
+            self.mat[0][1].signum() == self.mat[1][0].signum()
+        } else {
+            self.mat[0][0].signum() != self.mat[1][1].signum()
+        };
         let cos = self.mat[0][0];
         let sin = self.mat[1][0];
         let angle = match (cos, sin) {
@@ -368,15 +372,16 @@ impl Transformation {
     ///
     /// ```
     /// use geometry::transform::Transformation;
-    /// use approx::assert_relative_eq;
+    /// use geometry::transform::Rotation;
     ///
     /// let trans = Transformation::cascade(
-    ///     Transformation::rotate(90),
-    ///     Transformation::translate(5., 10),
+    ///     Transformation::rotate(Rotation::R90),
+    ///     Transformation::translate(5, 10),
     /// );
     /// let inv = trans.inv();
     ///
-    /// assert_relative_eq!(Transformation::cascade(inv, trans), Transformation::identity());
+    /// assert_eq!(Transformation::cascade(inv, trans), Transformation::identity());
+    /// assert_eq!(Transformation::cascade(trans, inv), Transformation::identity());
     /// ```
     pub fn inv(&self) -> Transformation {
         let inv = self.mat.inverse();

--- a/substrate/src/context.rs
+++ b/substrate/src/context.rs
@@ -561,7 +561,7 @@ impl<PDK: Pdk> PdkContext<PDK> {
                     LayoutCell::new(
                         block.clone(),
                         data,
-                        Arc::new(io),
+                        io,
                         Arc::new(cell_builder.finish(id, block.name()).with_ports(ports)),
                     )
                 })

--- a/substrate/src/io/impls.rs
+++ b/substrate/src/io/impls.rs
@@ -1,5 +1,8 @@
 //! Built-in implementations of IO traits.
 
+use geometry::point::Point;
+use geometry::transform::{TransformRef, TranslateRef};
+
 use crate::io::layout::{
     BundleBuilder, CustomHardwareType, HierarchicalBuildFrom, PortGeometryBuilder,
 };
@@ -653,19 +656,28 @@ where
     }
 }
 
-// TODO: Maybe do lazy transformation here.
-impl<T: HasTransformedView> HasTransformedView for ArrayData<T> {
-    type TransformedView = ArrayData<Transformed<T>>;
-
-    fn transformed_view(
-        &self,
-        trans: geometry::transform::Transformation,
-    ) -> Self::TransformedView {
-        Self::TransformedView {
+// TODO: Maybe do lazy translation here.
+impl<T: TranslateRef> TranslateRef for ArrayData<T> {
+    fn translate_ref(&self, p: Point) -> Self {
+        Self {
             elems: self
                 .elems
                 .iter()
-                .map(|elem| elem.transformed_view(trans))
+                .map(|elem| elem.translate_ref(p))
+                .collect(),
+            ty_len: self.ty_len,
+        }
+    }
+}
+
+// TODO: Maybe do lazy transformation here.
+impl<T: TransformRef> TransformRef for ArrayData<T> {
+    fn transform_ref(&self, trans: geometry::prelude::Transformation) -> Self {
+        Self {
+            elems: self
+                .elems
+                .iter()
+                .map(|elem| elem.transform_ref(trans))
                 .collect(),
             ty_len: self.ty_len,
         }

--- a/substrate/src/io/impls.rs
+++ b/substrate/src/io/impls.rs
@@ -656,7 +656,6 @@ where
     }
 }
 
-// TODO: Maybe do lazy translation here.
 impl<T: TranslateRef> TranslateRef for ArrayData<T> {
     fn translate_ref(&self, p: Point) -> Self {
         Self {
@@ -670,7 +669,6 @@ impl<T: TranslateRef> TranslateRef for ArrayData<T> {
     }
 }
 
-// TODO: Maybe do lazy transformation here.
 impl<T: TransformRef> TransformRef for ArrayData<T> {
     fn transform_ref(&self, trans: geometry::prelude::Transformation) -> Self {
         Self {

--- a/substrate/src/io/layout.rs
+++ b/substrate/src/io/layout.rs
@@ -10,7 +10,7 @@ pub use codegen::LayoutType as HardwareType;
 use geometry::point::Point;
 use geometry::prelude::{Bbox, Transformation};
 use geometry::rect::Rect;
-use geometry::transform::{self, TransformRef, TranslateRef};
+use geometry::transform::{TransformRef, TranslateRef};
 use geometry::union::BoundingUnion;
 use std::collections::HashMap;
 use substrate::layout::bbox::LayerBbox;

--- a/substrate/src/io/mod.rs
+++ b/substrate/src/io/mod.rs
@@ -7,7 +7,6 @@ use std::{
 
 use arcstr::ArcStr;
 pub use codegen::Io;
-use geometry::transform::{HasTransformedView, Transformed};
 use layout::{HardwareType as LayoutType, PortGeometry};
 use schematic::{HardwareType as SchematicType, Node};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Transformations now refer to Manhattan transformations;
non-Manhattan transformations are currently unsupported.
Remove transformed views, since the Manhattan transformed view of
any type is itself.
