### PR TITLE
fix(extract): throw error when Magic fails to write output netlists

### DIFF
--- a/tools/magic/src/extract.rs
+++ b/tools/magic/src/extract.rs
@@ -1,5 +1,6 @@
 use crate::utils::execute_run_script;
 use crate::{error::Error, TEMPLATES};
+use anyhow::anyhow;
 use serde::Serialize;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
@@ -77,10 +78,14 @@ fn run_extract_inner(
 }
 
 pub fn run_extract(params: &ExtractParams) -> Result<(), Error> {
+    let _ = std::fs::remove_file(params.netlist_path);
     let ExtractGeneratedPaths {
         run_script_path, ..
     } = write_extract_files(params)?;
     run_extract_inner(params.work_dir, run_script_path)?;
+    if !params.netlist_path.exists() {
+        return Err(anyhow!("magic failed to write output netlist").into());
+    }
     Ok(())
 }
 

--- a/tools/magic/src/pex.rs
+++ b/tools/magic/src/pex.rs
@@ -1,5 +1,6 @@
 use crate::utils::execute_run_script;
 use crate::{error::Error, TEMPLATES};
+use anyhow::anyhow;
 use serde::Serialize;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
@@ -75,10 +76,14 @@ fn run_pex_inner(
 }
 
 pub fn run_pex(params: &PexParams) -> Result<(), Error> {
+    let _ = std::fs::remove_file(params.pex_netlist_path);
     let PexGeneratedPaths {
         run_script_path, ..
     } = write_pex_files(params)?;
     run_pex_inner(params.work_dir, run_script_path)?;
+    if !params.pex_netlist_path.exists() {
+        return Err(anyhow!("magic failed to write output PEX netlist").into());
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Magic sometimes fails to perform extraction, but still exits with a 0
exit code. This tries to sanity check that the output netlist was newly
writen during LVS extraction or PEX extraction.
